### PR TITLE
Refactor getImageData() to remove nolint: gocyclo

### DIFF
--- a/cli/command/manifest/annotate.go
+++ b/cli/command/manifest/annotate.go
@@ -69,7 +69,7 @@ func runManifestAnnotate(dockerCli command.Cli, opts annotateOptions) error {
 	imgID := makeFilesafeName(imgRef.String())
 	logrus.Debugf("beginning annotate for %s/%s", transactionID, imgID)
 
-	imgInspect, _, err := getImageData(dockerCli, imgRef.String(), targetRef.String(), false)
+	imgInspect, _, err := getImageData(dockerCli, imgRef, targetRef.String(), false)
 	if err != nil {
 		return err
 	}

--- a/cli/command/manifest/cmd.go
+++ b/cli/command/manifest/cmd.go
@@ -10,8 +10,7 @@ import (
 )
 
 // NewManifestCommand returns a cobra command for `manifest` subcommands
-// nolint: interfacer
-func NewManifestCommand(dockerCli *command.DockerCli) *cobra.Command {
+func NewManifestCommand(dockerCli command.Cli) *cobra.Command {
 	// use dockerCli as command.Cli
 	cmd := &cobra.Command{
 		Use:   "manifest COMMAND",
@@ -32,8 +31,8 @@ func NewManifestCommand(dockerCli *command.DockerCli) *cobra.Command {
 }
 
 var manifestDescription = `
-The **docker manifest** command has subcommands for managing image manifests and 
-manifest lists. A manifest list allows you to use one name to refer to the same image 
+The **docker manifest** command has subcommands for managing image manifests and
+manifest lists. A manifest list allows you to use one name to refer to the same image
 built for multiple architectures.
 
 To see help for a subcommand, use:

--- a/cli/command/manifest/create_list.go
+++ b/cli/command/manifest/create_list.go
@@ -65,8 +65,13 @@ func createManifestList(dockerCli command.Cli, args []string, opts annotateOpts)
 	manifests := args[1:]
 	logrus.Debugf("retrieving digests of images...")
 	for _, manifestRef := range manifests {
+		namedRef, err := reference.ParseNormalizedNamed(manifestRef)
+		if err != nil {
+			// TODO: wrap error?
+			return err
+		}
 
-		mfstData, _, err := getImageData(dockerCli, manifestRef, targetRef.String(), false)
+		mfstData, _, err := getImageData(dockerCli, namedRef, targetRef.String(), false)
 		if err != nil {
 			return err
 		}

--- a/cli/command/manifest/fetch.go
+++ b/cli/command/manifest/fetch.go
@@ -16,23 +16,11 @@ import (
 	"github.com/docker/docker/registry"
 )
 
-// nolint: gocyclo
-func getImageData(dockerCli command.Cli, name string, transactionID string, fetchOnly bool) ([]fetcher.ImgManifestInspect, *registry.RepositoryInfo, error) {
-
-	var (
-		lastErr                    error
-		foundImages                []fetcher.ImgManifestInspect
-		confirmedTLSRegistries     = make(map[string]bool)
-		namedRef, transactionNamed reference.Named
-		err                        error
-		normalName                 string
-	)
-
-	if namedRef, err = reference.ParseNormalizedNamed(name); err != nil {
-		return nil, nil, errors.Wrapf(err, "Error parsing reference for %s: %s", name)
-	}
+func getLocalImageManifestData(namedRef reference.Named, transactionID string) ([]fetcher.ImgManifestInspect, *registry.RepositoryInfo, error) {
+	// TODO: extract as a function, duplicated in many places (Ex: annotate command)
 	if transactionID != "" {
-		if transactionNamed, err = reference.ParseNormalizedNamed(transactionID); err != nil {
+		transactionNamed, err := reference.ParseNormalizedNamed(transactionID)
+		if err != nil {
 			return nil, nil, errors.Wrapf(err, "Error parsing reference for %s: %s", transactionID)
 		}
 		if _, isDigested := transactionNamed.(reference.Canonical); !isDigested {
@@ -45,8 +33,7 @@ func getImageData(dockerCli command.Cli, name string, transactionID string, fetc
 	if _, isDigested := namedRef.(reference.Canonical); !isDigested {
 		namedRef = reference.TagNameOnly(namedRef)
 	}
-	normalName = namedRef.String()
-	logrus.Debugf("getting image data for ref: %s", normalName)
+	logrus.Debugf("getting image data for ref: %s", namedRef)
 
 	// Resolve the Repository name from fqn to RepositoryInfo
 	// This calls TrimNamed, which removes the tag, so always use namedRef for the image.
@@ -57,24 +44,30 @@ func getImageData(dockerCli command.Cli, name string, transactionID string, fetc
 
 	// If this is a manifest list, let's check for it locally so a user can see any modifications
 	// he/she has made.
-	logrus.Debugf("Checking locally for %s", normalName)
-	foundImages, err = loadManifest(makeFilesafeName(normalName), transactionID)
+	logrus.Debugf("Checking locally for %s", namedRef)
+	var foundImages []fetcher.ImgManifestInspect
+	foundImages, err = loadManifest(makeFilesafeName(namedRef.String()), transactionID)
 	if err != nil {
 		return nil, nil, err
 	}
 	if len(foundImages) > 0 {
-		// Great, no reason to pull from the registry.
 		return foundImages, repoInfo, nil
 	}
 	// For a manifest list request, the name should be used as the transactionID
-	foundImages, err = loadManifestList(normalName)
+	foundImages, err = loadManifestList(namedRef.String())
 	if err != nil {
 		return nil, nil, err
 	}
-	if len(foundImages) > 0 {
-		return foundImages, repoInfo, nil
+	return foundImages, repoInfo, nil
+}
+
+func getImageData(dockerCli command.Cli, namedRef reference.Named, transactionID string, fetchOnly bool) ([]fetcher.ImgManifestInspect, *registry.RepositoryInfo, error) {
+	foundImages, repoInfo, err := getLocalImageManifestData(namedRef, transactionID) // TODO:
+	if err != nil || len(foundImages) > 0 {
+		return foundImages, repoInfo, err
 	}
 
+	// TODO: this should be passed in
 	ctx := context.Background()
 
 	authConfig := command.ResolveAuthConfig(ctx, dockerCli, repoInfo.Index)
@@ -91,6 +84,8 @@ func getImageData(dockerCli command.Cli, name string, transactionID string, fetc
 	logrus.Debugf("manifest pull: endpoints: %v", endpoints)
 
 	// Try to find the first endpoint that is *both* v2 and using TLS.
+	var confirmedTLSRegistries = make(map[string]bool)
+	var lastErr error
 	for _, endpoint := range endpoints {
 		// make sure I can reach the registry, same as docker pull does
 		if endpoint.Version == registry.APIVersion1 {
@@ -105,7 +100,7 @@ func getImageData(dockerCli command.Cli, name string, transactionID string, fetc
 			}
 		}
 
-		logrus.Debugf("Trying to fetch image manifest of %s repository from %s %s", normalName, endpoint.URL, endpoint.Version)
+		logrus.Debugf("Trying to fetch image manifest of %s repository from %s %s", namedRef, endpoint.URL, endpoint.Version)
 
 		mfFetcher, err := fetcher.NewManifestFetcher(endpoint, repoInfo, authConfig, registryService)
 		if err != nil {
@@ -113,6 +108,7 @@ func getImageData(dockerCli command.Cli, name string, transactionID string, fetc
 			continue
 		}
 
+		var foundImages []fetcher.ImgManifestInspect
 		if foundImages, err = mfFetcher.Fetch(ctx, dockerCli, namedRef); err != nil {
 			// Can a manifest fetch be cancelled? I don't think so...
 			if _, ok := err.(fetcher.RecoverableError); ok {
@@ -126,13 +122,13 @@ func getImageData(dockerCli command.Cli, name string, transactionID string, fetc
 		}
 
 		if transactionID == "" && len(foundImages) > 1 {
-			transactionID = normalName
+			transactionID = namedRef.String()
 		}
 		// Additionally, we're never storing on inspect, so if we're asked to save images it's for a create,
 		// and this function will have been called for each image in the create. In that case we'll have an
 		// image name *and* a transaction ID. IOW, foundImages will be only one image.
 		if !fetchOnly {
-			if err := storeManifest(foundImages[0], makeFilesafeName(normalName), transactionID); err != nil {
+			if err := storeManifest(foundImages[0], makeFilesafeName(namedRef.String()), transactionID); err != nil {
 				logrus.Debugf("error storing manifests: %s", err)
 			}
 		}
@@ -140,7 +136,7 @@ func getImageData(dockerCli command.Cli, name string, transactionID string, fetc
 	}
 
 	if lastErr == nil {
-		lastErr = fmt.Errorf("no endpoints found for %s", normalName)
+		lastErr = fmt.Errorf("no endpoints found for %s", namedRef)
 	}
 
 	return nil, nil, lastErr
@@ -148,7 +144,6 @@ func getImageData(dockerCli command.Cli, name string, transactionID string, fetc
 }
 
 func loadManifest(manifest string, transaction string) ([]fetcher.ImgManifestInspect, error) {
-
 	// Load either a single manifest (if transaction is "", that's fine), or a
 	// manifest list
 	var foundImages []fetcher.ImgManifestInspect

--- a/cli/command/manifest/inspect.go
+++ b/cli/command/manifest/inspect.go
@@ -58,7 +58,7 @@ func runListInspect(dockerCli command.Cli, opts inspectOptions) error {
 		return err
 	}
 
-	if imgInspect, _, err = getImageData(dockerCli, named.String(), "", true); err != nil {
+	if imgInspect, _, err = getImageData(dockerCli, named, "", true); err != nil {
 		return err
 	}
 	// output basic informative details about the image

--- a/cli/command/manifest/push.go
+++ b/cli/command/manifest/push.go
@@ -202,7 +202,8 @@ func doListPush(ctx context.Context, dockerCli command.Cli, listPush manifestLis
 	}
 	putRequest.Header.Set("Content-Type", mediaType)
 
-	tr, err := fetcher.GetDistClientTransport(ctx, dockerCli, listPush.targetRepoInfo, listPush.targetEndpoint, listPush.targetName)
+	authConfig := command.ResolveAuthConfig(ctx, dockerCli, listPush.targetRepoInfo.Index)
+	tr, err := fetcher.GetDistClientTransport(authConfig, listPush.targetEndpoint, listPush.targetName)
 	if err != nil {
 		return errors.Wrap(err, "failed to setup HTTP client to repository")
 	}

--- a/cli/command/manifest/push.go
+++ b/cli/command/manifest/push.go
@@ -300,7 +300,12 @@ func listFromYAML(dockerCli command.Cli, targetRef reference.Named, targetRepoIn
 		listPush          manifestListPush
 	)
 	for _, mfEntry := range yamlInput.Manifests {
-		mfstInspects, repoInfo, err := getImageData(dockerCli, mfEntry.Image, targetRef.Name(), true)
+		namedRef, err := reference.ParseNormalizedNamed(mfEntry.Image)
+		if err != nil {
+			// TODO: wrap error?
+			return listPush, err
+		}
+		mfstInspects, repoInfo, err := getImageData(dockerCli, namedRef, targetRef.Name(), true)
 		if err != nil {
 			return listPush, err
 		}


### PR DESCRIPTION
Extract a few functions from `getImageData()`

Also:
* changed the signature to accept a `reference.Named` instead of a string for `namedRef`. We already have a reference.Named in most cases, and it's always nicer to accept stricter types.
* removed the `nolint: interfacer` whitelist
* remove the dependency on `command.Cli` from `cli/manfiest/fetcher`. It was only using it for `AuthConfig` which we can pass in
* refactored `ManifestFetcher`. Now only a single `Fetch` method is exposed, and `manifestFetcher` is just an implementation detail of the package. I noticed that 3 of the fields on the class were not used, so after removing them what was previously `ManifestFetcher()` was basically just a `Fetch()` that happened to use some other helpers that dependend on the `V2Repo` (which was the only field left on `manifestFetcher`.

I left some TODOs. 
* `context.Context` should be passed in from the command to `getImageData()`
* I think a lot of what's in `fetch.go` could be moved to `cli/manifest/fetcher`
* I noticed the logic  for reading/saving files to the local manifest store is a bit scattered. I'd like to create a `cli/manifest/store` package to consolidate, and provide a strict interface for interacting with those files.  I'll take this one later today or next week.

