### PR TITLE
Extract a manifest store

### DIFF
--- a/cli/command/cli.go
+++ b/cli/command/cli.go
@@ -5,13 +5,16 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"runtime"
 
 	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/config"
 	cliconfig "github.com/docker/cli/cli/config"
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/cli/config/credentials"
 	cliflags "github.com/docker/cli/cli/flags"
+	manifeststore "github.com/docker/cli/cli/manifest/store"
 	dopts "github.com/docker/cli/opts"
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types"
@@ -40,6 +43,7 @@ type Cli interface {
 	SetIn(in *InStream)
 	ConfigFile() *configfile.ConfigFile
 	CredentialsStore(serverAddress string) credentials.Store
+	ManifestStore() manifeststore.Store
 }
 
 // DockerCli is an instance the docker command line client.
@@ -139,6 +143,12 @@ func (cli *DockerCli) CredentialsStore(serverAddress string) credentials.Store {
 		return credentials.NewNativeStore(cli.configFile, helper)
 	}
 	return credentials.NewFileStore(cli.configFile)
+}
+
+// ManifestStore returns a store for local manifests
+func (cli *DockerCli) ManifestStore() manifeststore.Store {
+	// TODO: support override default location from config file
+	return manifeststore.NewStore(filepath.Join(config.Dir(), "manifests"))
 }
 
 // getConfiguredCredentialStore returns the credential helper configured for the

--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/cli/cli/command/config"
 	"github.com/docker/cli/cli/command/container"
 	"github.com/docker/cli/cli/command/image"
+	"github.com/docker/cli/cli/command/manifest"
 	"github.com/docker/cli/cli/command/network"
 	"github.com/docker/cli/cli/command/node"
 	"github.com/docker/cli/cli/command/plugin"
@@ -38,11 +39,14 @@ func AddCommands(cmd *cobra.Command, dockerCli *command.DockerCli) {
 		image.NewImageCommand(dockerCli),
 		image.NewBuildCommand(dockerCli),
 
-		// node
-		node.NewNodeCommand(dockerCli),
+		// manifest
+		manifest.NewManifestCommand(dockerCli),
 
 		// network
 		network.NewNetworkCommand(dockerCli),
+
+		// node
+		node.NewNodeCommand(dockerCli),
 
 		// plugin
 		plugin.NewPluginCommand(dockerCli),

--- a/cli/command/manifest/annotate.go
+++ b/cli/command/manifest/annotate.go
@@ -1,0 +1,122 @@
+package manifest
+
+import (
+	"fmt"
+
+	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/command"
+	"github.com/docker/distribution/reference"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+type annotateOptions struct {
+	target     string // the target manifest list name (also transaction ID)
+	image      string // the manifest to annotate within the list
+	variant    string // an architecture variant
+	os         string
+	arch       string
+	osFeatures []string
+}
+
+// NewAnnotateCommand creates a new `docker manifest annotate` command
+func newAnnotateCommand(dockerCli command.Cli) *cobra.Command {
+	var opts annotateOptions
+
+	cmd := &cobra.Command{
+		Use:   "annotate NAME[:TAG] [OPTIONS]",
+		Short: "Add additional information to an image's manifest.",
+		Args:  cli.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.target = args[0]
+			opts.image = args[1]
+			return runManifestAnnotate(dockerCli, opts)
+		},
+	}
+
+	flags := cmd.Flags()
+
+	flags.StringVar(&opts.os, "os", "", "Add os info to a manifest before pushing it.")
+	flags.StringVar(&opts.arch, "arch", "", "Add arch info to a manifest before pushing it.")
+	flags.StringSliceVar(&opts.osFeatures, "os-features", []string{}, "Add feature info to a manifest before pushing it.")
+	flags.StringVar(&opts.variant, "variant", "", "Add arch variant to a manifest before pushing it.")
+
+	return cmd
+}
+
+func runManifestAnnotate(dockerCli command.Cli, opts annotateOptions) error {
+
+	// Make sure the manifests are pulled, find the file you need, unmarshal the json, edit the file, and done.
+	targetRef, err := reference.ParseNormalizedNamed(opts.target)
+	if err != nil {
+		return errors.Wrapf(err, "annotate: Error parsing name for manifest list (%s): %s", opts.target)
+	}
+	imgRef, err := reference.ParseNormalizedNamed(opts.image)
+	if err != nil {
+		return errors.Wrapf(err, "annotate: Error prasing name for manifest (%s): %s:", opts.image)
+	}
+
+	// Make sure we've got tags or digests:
+	if _, isDigested := targetRef.(reference.Canonical); !isDigested {
+		targetRef = reference.TagNameOnly(targetRef)
+	}
+	if _, isDigested := imgRef.(reference.Canonical); !isDigested {
+		imgRef = reference.TagNameOnly(imgRef)
+	}
+	transactionID := makeFilesafeName(targetRef.String())
+	imgID := makeFilesafeName(imgRef.String())
+	logrus.Debugf("beginning annotate for %s/%s", transactionID, imgID)
+
+	imgInspect, _, err := getImageData(dockerCli, imgRef.String(), targetRef.String(), false)
+	if err != nil {
+		return err
+	}
+
+	if len(imgInspect) > 1 {
+		return fmt.Errorf("cannot annotate manifest list. Please pass an image (not list) name")
+	}
+
+	mf := imgInspect[0]
+
+	newMf, err := localManifestToManifestInspect(imgID, transactionID)
+	if err != nil {
+		return err
+	}
+
+	// Update the mf
+	if opts.os != "" {
+		newMf.OS = opts.os
+	}
+	if opts.arch != "" {
+		newMf.Architecture = opts.arch
+	}
+	for _, osFeature := range opts.osFeatures {
+		newMf.OSFeatures = appendIfUnique(mf.OSFeatures, osFeature)
+	}
+	if opts.variant != "" {
+		newMf.Variant = opts.variant
+	}
+
+	// validate os/arch input
+	if !isValidOSArch(newMf.OS, newMf.Architecture) {
+		return fmt.Errorf("manifest entry for image has unsupported os/arch combination: %s/%s", opts.os, opts.arch)
+	}
+
+	if err := updateMfFile(newMf, imgID, transactionID); err != nil {
+		return err
+	}
+
+	logrus.Debugf("annotated %s with options %v", mf.RefName, opts)
+	return nil
+}
+
+func appendIfUnique(list []string, str string) []string {
+	for _, s := range list {
+		if s == str {
+			return list
+		}
+	}
+	return append(list, str)
+}

--- a/cli/command/manifest/cmd.go
+++ b/cli/command/manifest/cmd.go
@@ -10,8 +10,7 @@ import (
 )
 
 // NewManifestCommand returns a cobra command for `manifest` subcommands
-// nolint: interfacer
-func NewManifestCommand(dockerCli *command.DockerCli) *cobra.Command {
+func NewManifestCommand(dockerCli command.Cli) *cobra.Command {
 	// use dockerCli as command.Cli
 	cmd := &cobra.Command{
 		Use:   "manifest COMMAND",
@@ -32,8 +31,8 @@ func NewManifestCommand(dockerCli *command.DockerCli) *cobra.Command {
 }
 
 var manifestDescription = `
-The **docker manifest** command has subcommands for managing image manifests and 
-manifest lists. A manifest list allows you to use one name to refer to the same image 
+The **docker manifest** command has subcommands for managing image manifests and
+manifest lists. A manifest list allows you to use one name to refer to the same image
 built for multiple architectures.
 
 To see help for a subcommand, use:

--- a/cli/command/manifest/cmd.go
+++ b/cli/command/manifest/cmd.go
@@ -1,0 +1,45 @@
+package manifest
+
+import (
+	"fmt"
+
+	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/command"
+
+	"github.com/spf13/cobra"
+)
+
+// NewManifestCommand returns a cobra command for `manifest` subcommands
+// nolint: interfacer
+func NewManifestCommand(dockerCli *command.DockerCli) *cobra.Command {
+	// use dockerCli as command.Cli
+	cmd := &cobra.Command{
+		Use:   "manifest COMMAND",
+		Short: "Manage Docker image manifests and lists",
+		Long:  manifestDescription,
+		Args:  cli.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Fprintf(dockerCli.Err(), "\n"+cmd.UsageString())
+		},
+	}
+	cmd.AddCommand(
+		newCreateListCommand(dockerCli),
+		newInspectCommand(dockerCli),
+		newAnnotateCommand(dockerCli),
+		newPushListCommand(dockerCli),
+	)
+	return cmd
+}
+
+var manifestDescription = `
+The **docker manifest** command has subcommands for managing image manifests and 
+manifest lists. A manifest list allows you to use one name to refer to the same image 
+built for multiple architectures.
+
+To see help for a subcommand, use:
+
+    docker manifest CMD help
+
+For full details on using docker manifest lists view the registry v2 specification.
+
+`

--- a/cli/command/manifest/create_list.go
+++ b/cli/command/manifest/create_list.go
@@ -4,13 +4,12 @@ import (
 	"fmt"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
-
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
-	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/registry"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
 )
 
 type annotateOpts struct {
@@ -18,7 +17,6 @@ type annotateOpts struct {
 }
 
 func newCreateListCommand(dockerCli command.Cli) *cobra.Command {
-
 	opts := annotateOpts{}
 
 	cmd := &cobra.Command{
@@ -36,46 +34,46 @@ func newCreateListCommand(dockerCli command.Cli) *cobra.Command {
 }
 
 func createManifestList(dockerCli command.Cli, args []string, opts annotateOpts) error {
-
-	// Just do some basic verification here, and leave the rest for when the user pushes the list
 	newRef := args[0]
-	targetRef, err := reference.ParseNormalizedNamed(newRef)
+	targetRef, err := normalizeReference(newRef)
 	if err != nil {
 		return errors.Wrapf(err, "error parsing name for manifest list (%s): %v", newRef)
 	}
+
+	// TODO: why is this here?
 	_, err = registry.ParseRepositoryInfo(targetRef)
 	if err != nil {
 		return errors.Wrapf(err, "error parsing repository name for manifest list (%s): %v", newRef)
 	}
 
-	// Check locally for this list transaction before proceeding
-	if _, isDigested := targetRef.(reference.Canonical); !isDigested {
-		targetRef = reference.TagNameOnly(targetRef)
-	}
-	manifestFiles, err := getListFilenames(makeFilesafeName(targetRef.String()))
+	manifestStore := dockerCli.ManifestStore()
+	list, err := manifestStore.GetList(targetRef)
 	if err != nil {
 		return err
 	}
-	if len(manifestFiles) > 0 && !opts.amend {
+	if len(list) > 0 && !opts.amend {
 		return fmt.Errorf("refusing to continue over an existing manifest list transaction with no --amend flag")
 	}
 
+	ctx := context.Background()
 	// Now create the local manifest list transaction by looking up the manifest schemas
 	// for the constituent images:
 	manifests := args[1:]
 	logrus.Debugf("retrieving digests of images...")
 	for _, manifestRef := range manifests {
-
-		mfstData, _, err := getImageData(dockerCli, manifestRef, targetRef.String(), false)
+		namedRef, err := normalizeReference(manifestRef)
 		if err != nil {
+			// TODO: wrap error?
 			return err
 		}
 
-		if len(mfstData) > 1 {
-			// too many responses--can only happen if a manifest list was returned for the name lookup
-			return fmt.Errorf("manifest lists cannot embed another manifest list")
+		manifest, err := getManifest(ctx, dockerCli, targetRef, namedRef)
+		if err != nil {
+			return err
 		}
-
+		if err := manifestStore.Save(targetRef, namedRef, manifest); err != nil {
+			return err
+		}
 	}
 	logrus.Infof("successfully started manifest list transaction for %s", targetRef.String())
 	return nil

--- a/cli/command/manifest/create_list.go
+++ b/cli/command/manifest/create_list.go
@@ -1,0 +1,82 @@
+package manifest
+
+import (
+	"fmt"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/command"
+	"github.com/docker/distribution/reference"
+	"github.com/docker/docker/registry"
+)
+
+type annotateOpts struct {
+	amend bool
+}
+
+func newCreateListCommand(dockerCli command.Cli) *cobra.Command {
+
+	opts := annotateOpts{}
+
+	cmd := &cobra.Command{
+		Use:   "create newRef manifest [manifest...]",
+		Short: "Create a local manifest list for annotating and pushing to a registry",
+		Args:  cli.RequiresMinArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return createManifestList(dockerCli, args, opts)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.BoolVarP(&opts.amend, "amend", "a", false, "Amend an existing manifest list transaction")
+	return cmd
+}
+
+func createManifestList(dockerCli command.Cli, args []string, opts annotateOpts) error {
+
+	// Just do some basic verification here, and leave the rest for when the user pushes the list
+	newRef := args[0]
+	targetRef, err := reference.ParseNormalizedNamed(newRef)
+	if err != nil {
+		return errors.Wrapf(err, "error parsing name for manifest list (%s): %v", newRef)
+	}
+	_, err = registry.ParseRepositoryInfo(targetRef)
+	if err != nil {
+		return errors.Wrapf(err, "error parsing repository name for manifest list (%s): %v", newRef)
+	}
+
+	// Check locally for this list transaction before proceeding
+	if _, isDigested := targetRef.(reference.Canonical); !isDigested {
+		targetRef = reference.TagNameOnly(targetRef)
+	}
+	manifestFiles, err := getListFilenames(makeFilesafeName(targetRef.String()))
+	if err != nil {
+		return err
+	}
+	if len(manifestFiles) > 0 && !opts.amend {
+		return fmt.Errorf("refusing to continue over an existing manifest list transaction with no --amend flag")
+	}
+
+	// Now create the local manifest list transaction by looking up the manifest schemas
+	// for the constituent images:
+	manifests := args[1:]
+	logrus.Debugf("retrieving digests of images...")
+	for _, manifestRef := range manifests {
+
+		mfstData, _, err := getImageData(dockerCli, manifestRef, targetRef.String(), false)
+		if err != nil {
+			return err
+		}
+
+		if len(mfstData) > 1 {
+			// too many responses--can only happen if a manifest list was returned for the name lookup
+			return fmt.Errorf("manifest lists cannot embed another manifest list")
+		}
+
+	}
+	logrus.Infof("successfully started manifest list transaction for %s", targetRef.String())
+	return nil
+}

--- a/cli/command/manifest/fetch.go
+++ b/cli/command/manifest/fetch.go
@@ -1,98 +1,91 @@
 package manifest
 
 import (
-	"fmt"
-	"os"
-	"path/filepath"
-	"strings"
-
 	"github.com/Sirupsen/logrus"
-	"github.com/pkg/errors"
-	"golang.org/x/net/context"
-
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/manifest/fetcher"
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/registry"
+	"github.com/pkg/errors"
+	"golang.org/x/net/context"
 )
 
-// nolint: gocyclo
-func getImageData(dockerCli command.Cli, name string, transactionID string, fetchOnly bool) ([]fetcher.ImgManifestInspect, *registry.RepositoryInfo, error) {
-
-	var (
-		lastErr                    error
-		foundImages                []fetcher.ImgManifestInspect
-		confirmedTLSRegistries     = make(map[string]bool)
-		namedRef, transactionNamed reference.Named
-		err                        error
-		normalName                 string
-	)
-
-	if namedRef, err = reference.ParseNormalizedNamed(name); err != nil {
-		return nil, nil, errors.Wrapf(err, "Error parsing reference for %s: %s", name)
+func getManifest(ctx context.Context, dockerCli command.Cli, listRef, namedRef reference.Named) (fetcher.ImgManifestInspect, error) {
+	data, err := dockerCli.ManifestStore().Get(listRef, namedRef)
+	switch {
+	case err != nil:
+		return fetcher.ImgManifestInspect{}, err
+	case data != nil:
+		return *data, nil
 	}
-	if transactionID != "" {
-		if transactionNamed, err = reference.ParseNormalizedNamed(transactionID); err != nil {
-			return nil, nil, errors.Wrapf(err, "Error parsing reference for %s: %s", transactionID)
-		}
-		if _, isDigested := transactionNamed.(reference.Canonical); !isDigested {
-			transactionNamed = reference.TagNameOnly(transactionNamed)
-		}
-		transactionID = makeFilesafeName(transactionNamed.String())
+	return getRemoteManifest(ctx, dockerCli, namedRef)
+}
+
+func getRemoteManifest(ctx context.Context, dockerCli command.Cli, namedRef reference.Named) (fetcher.ImgManifestInspect, error) {
+	opts, endpoints, err := newFetchOptionsForReference(ctx, dockerCli, namedRef)
+	if err != nil {
+		return fetcher.ImgManifestInspect{}, err
 	}
 
-	// Make sure these have a tag, as long as it's not a digest
-	if _, isDigested := namedRef.(reference.Canonical); !isDigested {
-		namedRef = reference.TagNameOnly(namedRef)
+	var result fetcher.ImgManifestInspect
+	fetchManifestOnly := func(endpoint registry.APIEndpoint) (bool, error) {
+		logrus.Debugf("Trying to fetch image manifest of %s repository from %s %s", opts.NamedRef, endpoint.URL, endpoint.Version)
+		var err error
+		result, err = fetcher.FetchManifest(ctx, opts)
+		return result.RefName != "", err
 	}
-	normalName = namedRef.String()
-	logrus.Debugf("getting image data for ref: %s", normalName)
 
-	// Resolve the Repository name from fqn to RepositoryInfo
-	// This calls TrimNamed, which removes the tag, so always use namedRef for the image.
+	err = iterateEndpoints(endpoints, fetchManifestOnly)
+	return result, err
+}
+
+func newFetchOptionsForReference(ctx context.Context, dockerCli command.Cli, namedRef reference.Named) (fetcher.FetchOptions, []registry.APIEndpoint, error) {
 	repoInfo, err := registry.ParseRepositoryInfo(namedRef)
 	if err != nil {
-		return nil, nil, err
+		return fetcher.FetchOptions{}, nil, err
 	}
-
-	// If this is a manifest list, let's check for it locally so a user can see any modifications
-	// he/she has made.
-	logrus.Debugf("Checking locally for %s", normalName)
-	foundImages, err = loadManifest(makeFilesafeName(normalName), transactionID)
-	if err != nil {
-		return nil, nil, err
-	}
-	if len(foundImages) > 0 {
-		// Great, no reason to pull from the registry.
-		return foundImages, repoInfo, nil
-	}
-	// For a manifest list request, the name should be used as the transactionID
-	foundImages, err = loadManifestList(normalName)
-	if err != nil {
-		return nil, nil, err
-	}
-	if len(foundImages) > 0 {
-		return foundImages, repoInfo, nil
-	}
-
-	ctx := context.Background()
-
-	authConfig := command.ResolveAuthConfig(ctx, dockerCli, repoInfo.Index)
-
-	options := registry.ServiceOptions{}
-	registryService := registry.NewService(options)
+	registryService := registry.NewService(registry.ServiceOptions{})
 
 	// a list of registry.APIEndpoint, which could be mirrors, etc., of locally-configured
 	// repo endpoints. The list will be ordered by priority (v2, https, v1).
 	endpoints, err := registryService.LookupPullEndpoints(reference.Domain(repoInfo.Name))
 	if err != nil {
-		return nil, nil, err
+		return fetcher.FetchOptions{}, nil, err
 	}
 	logrus.Debugf("manifest pull: endpoints: %v", endpoints)
 
-	// Try to find the first endpoint that is *both* v2 and using TLS.
+	return fetcher.FetchOptions{
+		AuthConfig: command.ResolveAuthConfig(ctx, dockerCli, repoInfo.Index),
+		RepoInfo:   repoInfo,
+		NamedRef:   namedRef,
+	}, endpoints, nil
+}
+
+func getRemoteManifestOrManifestList(ctx context.Context, dockerCli command.Cli, namedRef reference.Named) ([]fetcher.ImgManifestInspect, error) {
+	opts, endpoints, err := newFetchOptionsForReference(ctx, dockerCli, namedRef)
+	if err != nil {
+		return nil, err
+	}
+
+	result := []fetcher.ImgManifestInspect{}
+	fetchAny := func(endpoint registry.APIEndpoint) (bool, error) {
+		logrus.Debugf("Trying to fetch image manifest of %s repository from %s %s", opts.NamedRef, endpoint.URL, endpoint.Version)
+		foundImages, err := fetcher.Fetch(ctx, opts)
+		return len(foundImages) > 0, err
+	}
+
+	if err = iterateEndpoints(endpoints, fetchAny); err != nil {
+		return nil, err
+	}
+	if len(result) == 0 {
+		return nil, errors.Errorf("no endpoints found for %s", namedRef)
+	}
+	return result, nil
+}
+
+func iterateEndpoints(endpoints []registry.APIEndpoint, each func(endpoint registry.APIEndpoint) (bool, error)) error {
+	confirmedTLSRegistries := make(map[string]bool)
 	for _, endpoint := range endpoints {
-		// make sure I can reach the registry, same as docker pull does
 		if endpoint.Version == registry.APIVersion1 {
 			logrus.Debugf("Skipping v1 endpoint %s", endpoint.URL)
 			continue
@@ -105,15 +98,8 @@ func getImageData(dockerCli command.Cli, name string, transactionID string, fetc
 			}
 		}
 
-		logrus.Debugf("Trying to fetch image manifest of %s repository from %s %s", normalName, endpoint.URL, endpoint.Version)
-
-		mfFetcher, err := fetcher.NewManifestFetcher(endpoint, repoInfo, authConfig, registryService)
+		done, err := each(endpoint)
 		if err != nil {
-			lastErr = err
-			continue
-		}
-
-		if foundImages, err = mfFetcher.Fetch(ctx, dockerCli, namedRef); err != nil {
 			// Can a manifest fetch be cancelled? I don't think so...
 			if _, ok := err.(fetcher.RecoverableError); ok {
 				if endpoint.URL.Scheme == "https" {
@@ -121,85 +107,11 @@ func getImageData(dockerCli command.Cli, name string, transactionID string, fetc
 				}
 				continue
 			}
-			logrus.Debugf("not continuing with fetch after unrecoverable error: %v", err)
-			return nil, nil, err
+			return err
 		}
-
-		if transactionID == "" && len(foundImages) > 1 {
-			transactionID = normalName
-		}
-		// Additionally, we're never storing on inspect, so if we're asked to save images it's for a create,
-		// and this function will have been called for each image in the create. In that case we'll have an
-		// image name *and* a transaction ID. IOW, foundImages will be only one image.
-		if !fetchOnly {
-			if err := storeManifest(foundImages[0], makeFilesafeName(normalName), transactionID); err != nil {
-				logrus.Debugf("error storing manifests: %s", err)
-			}
-		}
-		return foundImages, repoInfo, nil
-	}
-
-	if lastErr == nil {
-		lastErr = fmt.Errorf("no endpoints found for %s", normalName)
-	}
-
-	return nil, nil, lastErr
-
-}
-
-func loadManifest(manifest string, transaction string) ([]fetcher.ImgManifestInspect, error) {
-
-	// Load either a single manifest (if transaction is "", that's fine), or a
-	// manifest list
-	var foundImages []fetcher.ImgManifestInspect
-	fd, err := getManifestFd(manifest, transaction)
-	if err != nil {
-		if _, dirOpen := err.(dirOpenError); !dirOpen {
-			return nil, err
+		if done {
+			return nil
 		}
 	}
-	if fd != nil {
-		defer fd.Close()
-		_, err := fd.Stat()
-		if err != nil {
-			return nil, err
-		}
-		mfInspect, err := localManifestToManifestInspect(manifest, transaction)
-		if err != nil {
-			return nil, err
-		}
-		foundImages = append(foundImages, mfInspect)
-	}
-	return foundImages, nil
-}
-
-func loadManifestList(transaction string) (foundImages []fetcher.ImgManifestInspect, _ error) {
-	manifests, err := getListFilenames(transaction)
-	if err != nil {
-		return nil, err
-	}
-	for _, manifestFile := range manifests {
-		fileParts := strings.Split(manifestFile, string(filepath.Separator))
-		numParts := len(fileParts)
-		mfInspect, err := localManifestToManifestInspect(fileParts[numParts-1], transaction)
-		if err != nil {
-			return nil, err
-		}
-		foundImages = append(foundImages, mfInspect)
-	}
-	return foundImages, nil
-}
-
-func storeManifest(imgInspect fetcher.ImgManifestInspect, name, transaction string) error {
-	// Store this image manifest so that it can be annotated.
-	// Store the manifests in a user's home to prevent conflict.
-	manifestBase, err := buildBaseFilename()
-	transaction = makeFilesafeName(transaction)
-	if err != nil {
-		return err
-	}
-	os.MkdirAll(filepath.Join(manifestBase, transaction), 0755)
-	logrus.Debugf("Storing  %s", name)
-
-	return updateMfFile(imgInspect, name, transaction)
+	return nil
 }

--- a/cli/command/manifest/fetch.go
+++ b/cli/command/manifest/fetch.go
@@ -1,0 +1,205 @@
+package manifest
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/pkg/errors"
+	"golang.org/x/net/context"
+
+	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/manifest/fetcher"
+	"github.com/docker/distribution/reference"
+	"github.com/docker/docker/registry"
+)
+
+// nolint: gocyclo
+func getImageData(dockerCli command.Cli, name string, transactionID string, fetchOnly bool) ([]fetcher.ImgManifestInspect, *registry.RepositoryInfo, error) {
+
+	var (
+		lastErr                    error
+		foundImages                []fetcher.ImgManifestInspect
+		confirmedTLSRegistries     = make(map[string]bool)
+		namedRef, transactionNamed reference.Named
+		err                        error
+		normalName                 string
+	)
+
+	if namedRef, err = reference.ParseNormalizedNamed(name); err != nil {
+		return nil, nil, errors.Wrapf(err, "Error parsing reference for %s: %s", name)
+	}
+	if transactionID != "" {
+		if transactionNamed, err = reference.ParseNormalizedNamed(transactionID); err != nil {
+			return nil, nil, errors.Wrapf(err, "Error parsing reference for %s: %s", transactionID)
+		}
+		if _, isDigested := transactionNamed.(reference.Canonical); !isDigested {
+			transactionNamed = reference.TagNameOnly(transactionNamed)
+		}
+		transactionID = makeFilesafeName(transactionNamed.String())
+	}
+
+	// Make sure these have a tag, as long as it's not a digest
+	if _, isDigested := namedRef.(reference.Canonical); !isDigested {
+		namedRef = reference.TagNameOnly(namedRef)
+	}
+	normalName = namedRef.String()
+	logrus.Debugf("getting image data for ref: %s", normalName)
+
+	// Resolve the Repository name from fqn to RepositoryInfo
+	// This calls TrimNamed, which removes the tag, so always use namedRef for the image.
+	repoInfo, err := registry.ParseRepositoryInfo(namedRef)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// If this is a manifest list, let's check for it locally so a user can see any modifications
+	// he/she has made.
+	logrus.Debugf("Checking locally for %s", normalName)
+	foundImages, err = loadManifest(makeFilesafeName(normalName), transactionID)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(foundImages) > 0 {
+		// Great, no reason to pull from the registry.
+		return foundImages, repoInfo, nil
+	}
+	// For a manifest list request, the name should be used as the transactionID
+	foundImages, err = loadManifestList(normalName)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(foundImages) > 0 {
+		return foundImages, repoInfo, nil
+	}
+
+	ctx := context.Background()
+
+	authConfig := command.ResolveAuthConfig(ctx, dockerCli, repoInfo.Index)
+
+	options := registry.ServiceOptions{}
+	registryService := registry.NewService(options)
+
+	// a list of registry.APIEndpoint, which could be mirrors, etc., of locally-configured
+	// repo endpoints. The list will be ordered by priority (v2, https, v1).
+	endpoints, err := registryService.LookupPullEndpoints(reference.Domain(repoInfo.Name))
+	if err != nil {
+		return nil, nil, err
+	}
+	logrus.Debugf("manifest pull: endpoints: %v", endpoints)
+
+	// Try to find the first endpoint that is *both* v2 and using TLS.
+	for _, endpoint := range endpoints {
+		// make sure I can reach the registry, same as docker pull does
+		if endpoint.Version == registry.APIVersion1 {
+			logrus.Debugf("Skipping v1 endpoint %s", endpoint.URL)
+			continue
+		}
+
+		if endpoint.URL.Scheme != "https" {
+			if _, confirmedTLS := confirmedTLSRegistries[endpoint.URL.Host]; confirmedTLS {
+				logrus.Debugf("Skipping non-TLS endpoint %s for host/port that appears to use TLS", endpoint.URL)
+				continue
+			}
+		}
+
+		logrus.Debugf("Trying to fetch image manifest of %s repository from %s %s", normalName, endpoint.URL, endpoint.Version)
+
+		mfFetcher, err := fetcher.NewManifestFetcher(endpoint, repoInfo, authConfig, registryService)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+
+		if foundImages, err = mfFetcher.Fetch(ctx, dockerCli, namedRef); err != nil {
+			// Can a manifest fetch be cancelled? I don't think so...
+			if _, ok := err.(fetcher.RecoverableError); ok {
+				if endpoint.URL.Scheme == "https" {
+					confirmedTLSRegistries[endpoint.URL.Host] = true
+				}
+				continue
+			}
+			logrus.Debugf("not continuing with fetch after unrecoverable error: %v", err)
+			return nil, nil, err
+		}
+
+		if transactionID == "" && len(foundImages) > 1 {
+			transactionID = normalName
+		}
+		// Additionally, we're never storing on inspect, so if we're asked to save images it's for a create,
+		// and this function will have been called for each image in the create. In that case we'll have an
+		// image name *and* a transaction ID. IOW, foundImages will be only one image.
+		if !fetchOnly {
+			if err := storeManifest(foundImages[0], makeFilesafeName(normalName), transactionID); err != nil {
+				logrus.Debugf("error storing manifests: %s", err)
+			}
+		}
+		return foundImages, repoInfo, nil
+	}
+
+	if lastErr == nil {
+		lastErr = fmt.Errorf("no endpoints found for %s", normalName)
+	}
+
+	return nil, nil, lastErr
+
+}
+
+func loadManifest(manifest string, transaction string) ([]fetcher.ImgManifestInspect, error) {
+
+	// Load either a single manifest (if transaction is "", that's fine), or a
+	// manifest list
+	var foundImages []fetcher.ImgManifestInspect
+	fd, err := getManifestFd(manifest, transaction)
+	if err != nil {
+		if _, dirOpen := err.(dirOpenError); !dirOpen {
+			return nil, err
+		}
+	}
+	if fd != nil {
+		defer fd.Close()
+		_, err := fd.Stat()
+		if err != nil {
+			return nil, err
+		}
+		mfInspect, err := localManifestToManifestInspect(manifest, transaction)
+		if err != nil {
+			return nil, err
+		}
+		foundImages = append(foundImages, mfInspect)
+	}
+	return foundImages, nil
+}
+
+func loadManifestList(transaction string) (foundImages []fetcher.ImgManifestInspect, _ error) {
+	manifests, err := getListFilenames(transaction)
+	if err != nil {
+		return nil, err
+	}
+	for _, manifestFile := range manifests {
+		fileParts := strings.Split(manifestFile, string(filepath.Separator))
+		numParts := len(fileParts)
+		mfInspect, err := localManifestToManifestInspect(fileParts[numParts-1], transaction)
+		if err != nil {
+			return nil, err
+		}
+		foundImages = append(foundImages, mfInspect)
+	}
+	return foundImages, nil
+}
+
+func storeManifest(imgInspect fetcher.ImgManifestInspect, name, transaction string) error {
+	// Store this image manifest so that it can be annotated.
+	// Store the manifests in a user's home to prevent conflict.
+	manifestBase, err := buildBaseFilename()
+	transaction = makeFilesafeName(transaction)
+	if err != nil {
+		return err
+	}
+	os.MkdirAll(filepath.Join(manifestBase, transaction), 0755)
+	logrus.Debugf("Storing  %s", name)
+
+	return updateMfFile(imgInspect, name, transaction)
+}

--- a/cli/command/manifest/inspect.go
+++ b/cli/command/manifest/inspect.go
@@ -5,14 +5,14 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/spf13/cobra"
-
 	"github.com/docker/cli/cli"
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/manifest/fetcher"
 	"github.com/docker/distribution/manifest/manifestlist"
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/registry"
+	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
 )
 
 type inspectOptions struct {
@@ -26,7 +26,7 @@ func newInspectCommand(dockerCli command.Cli) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "inspect [OPTIONS] NAME[:TAG]",
-		Short: "Display an image's manifest, or a remote manifest list.",
+		Short: "Display an image manifest, or a remote manifest list",
 		Args:  cli.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.remote = args[0]
@@ -35,57 +35,60 @@ func newInspectCommand(dockerCli command.Cli) *cobra.Command {
 	}
 
 	flags := cmd.Flags()
-
 	flags.BoolVarP(&opts.verbose, "verbose", "v", false, "Output additional info including layers and platform")
-
 	return cmd
 }
 
 func runListInspect(dockerCli command.Cli, opts inspectOptions) error {
-
-	// Get the data and then format it
-	var (
-		imgInspect []fetcher.ImgManifestInspect
-		prettyJSON bytes.Buffer
-	)
-
-	named, err := reference.ParseNormalizedNamed(opts.remote)
-	if err != nil {
-		return err
-	}
-	targetRepo, err := registry.ParseRepositoryInfo(named)
+	namedRef, err := normalizeReference(opts.remote)
 	if err != nil {
 		return err
 	}
 
-	if imgInspect, _, err = getImageData(dockerCli, named.String(), "", true); err != nil {
+	localManifestList, err := dockerCli.ManifestStore().GetList(namedRef)
+	if err == nil {
+		return printManifestList(dockerCli, namedRef, localManifestList, opts)
+	}
+
+	ctx := context.Background()
+	imgInspect, err := getRemoteManifestOrManifestList(ctx, dockerCli, namedRef)
+	if err != nil {
 		return err
 	}
-	// output basic informative details about the image
 	if len(imgInspect) == 1 {
-		// this is a basic single manifest
-		if !opts.verbose {
-			err = json.Indent(&prettyJSON, imgInspect[0].CanonicalJSON, "", "    ")
-			if err != nil {
-				return err
-			}
-			fmt.Fprintln(dockerCli.Out(), prettyJSON.String())
-			return nil
-		}
-		jsonBytes, err := json.MarshalIndent(imgInspect[0], "", "\t")
+		return printManifest(dockerCli, imgInspect[0], opts)
+	}
+	return printManifestList(dockerCli, namedRef, imgInspect, opts)
+}
+
+func printManifest(dockerCli command.Cli, manifest fetcher.ImgManifestInspect, opts inspectOptions) error {
+	buffer := new(bytes.Buffer)
+	if !opts.verbose {
+		err := json.Indent(buffer, manifest.CanonicalJSON, "", "\t")
 		if err != nil {
 			return err
 		}
-		fmt.Fprintln(dockerCli.Out(), "combined image and manifest summary:")
-		dockerCli.Out().Write(jsonBytes)
-		fmt.Println()
+		fmt.Fprintln(dockerCli.Out(), buffer.String())
 		return nil
 	}
+	jsonBytes, err := json.MarshalIndent(manifest, "", "\t")
+	if err != nil {
+		return err
+	}
+	dockerCli.Out().Write(append(jsonBytes, '\n'))
+	return nil
+}
 
+func printManifestList(dockerCli command.Cli, namedRef reference.Named, list []fetcher.ImgManifestInspect, opts inspectOptions) error {
 	if !opts.verbose {
+		targetRepo, err := registry.ParseRepositoryInfo(namedRef)
+		if err != nil {
+			return err
+		}
+
 		manifests := []manifestlist.ManifestDescriptor{}
 		// More than one response. This is a manifest list.
-		for _, img := range imgInspect {
+		for _, img := range list {
 			mfd, _, err := buildManifestObj(targetRepo, img)
 			if err != nil {
 				return fmt.Errorf("error assembling ManifestDescriptor")
@@ -103,14 +106,10 @@ func runListInspect(dockerCli command.Cli, opts inspectOptions) error {
 		fmt.Fprintln(dockerCli.Out(), string(jsonBytes))
 		return nil
 	}
-	fmt.Fprintln(dockerCli.Out(), "combined image and manifest summaries:")
-	for _, img := range imgInspect {
-		jsonBytes, err := json.MarshalIndent(img, "", "\t")
-		if err != nil {
-			return err
-		}
-		dockerCli.Out().Write(jsonBytes)
-		fmt.Println()
+	jsonBytes, err := json.MarshalIndent(list, "", "\t")
+	if err != nil {
+		return err
 	}
+	dockerCli.Out().Write(append(jsonBytes, '\n'))
 	return nil
 }

--- a/cli/command/manifest/inspect.go
+++ b/cli/command/manifest/inspect.go
@@ -1,0 +1,116 @@
+package manifest
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/manifest/fetcher"
+	"github.com/docker/distribution/manifest/manifestlist"
+	"github.com/docker/distribution/reference"
+	"github.com/docker/docker/registry"
+)
+
+type inspectOptions struct {
+	remote  string
+	verbose bool
+}
+
+// NewInspectCommand creates a new `docker manifest inspect` command
+func newInspectCommand(dockerCli command.Cli) *cobra.Command {
+	var opts inspectOptions
+
+	cmd := &cobra.Command{
+		Use:   "inspect [OPTIONS] NAME[:TAG]",
+		Short: "Display an image's manifest, or a remote manifest list.",
+		Args:  cli.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.remote = args[0]
+			return runListInspect(dockerCli, opts)
+		},
+	}
+
+	flags := cmd.Flags()
+
+	flags.BoolVarP(&opts.verbose, "verbose", "v", false, "Output additional info including layers and platform")
+
+	return cmd
+}
+
+func runListInspect(dockerCli command.Cli, opts inspectOptions) error {
+
+	// Get the data and then format it
+	var (
+		imgInspect []fetcher.ImgManifestInspect
+		prettyJSON bytes.Buffer
+	)
+
+	named, err := reference.ParseNormalizedNamed(opts.remote)
+	if err != nil {
+		return err
+	}
+	targetRepo, err := registry.ParseRepositoryInfo(named)
+	if err != nil {
+		return err
+	}
+
+	if imgInspect, _, err = getImageData(dockerCli, named.String(), "", true); err != nil {
+		return err
+	}
+	// output basic informative details about the image
+	if len(imgInspect) == 1 {
+		// this is a basic single manifest
+		if !opts.verbose {
+			err = json.Indent(&prettyJSON, imgInspect[0].CanonicalJSON, "", "    ")
+			if err != nil {
+				return err
+			}
+			fmt.Fprintln(dockerCli.Out(), prettyJSON.String())
+			return nil
+		}
+		jsonBytes, err := json.MarshalIndent(imgInspect[0], "", "\t")
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(dockerCli.Out(), "combined image and manifest summary:")
+		dockerCli.Out().Write(jsonBytes)
+		fmt.Println()
+		return nil
+	}
+
+	if !opts.verbose {
+		manifests := []manifestlist.ManifestDescriptor{}
+		// More than one response. This is a manifest list.
+		for _, img := range imgInspect {
+			mfd, _, err := buildManifestObj(targetRepo, img)
+			if err != nil {
+				return fmt.Errorf("error assembling ManifestDescriptor")
+			}
+			manifests = append(manifests, mfd)
+		}
+		deserializedML, err := manifestlist.FromDescriptors(manifests)
+		if err != nil {
+			return err
+		}
+		jsonBytes, err := deserializedML.MarshalJSON()
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(dockerCli.Out(), string(jsonBytes))
+		return nil
+	}
+	fmt.Fprintln(dockerCli.Out(), "combined image and manifest summaries:")
+	for _, img := range imgInspect {
+		jsonBytes, err := json.MarshalIndent(img, "", "\t")
+		if err != nil {
+			return err
+		}
+		dockerCli.Out().Write(jsonBytes)
+		fmt.Println()
+	}
+	return nil
+}

--- a/cli/command/manifest/push.go
+++ b/cli/command/manifest/push.go
@@ -1,0 +1,627 @@
+package manifest
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"golang.org/x/net/context"
+	"gopkg.in/yaml.v2"
+
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/manifest/manifestlist"
+	"github.com/docker/distribution/reference"
+	"github.com/docker/distribution/registry/api/v2"
+	"github.com/docker/distribution/registry/client"
+	digest "github.com/opencontainers/go-digest"
+
+	//"github.com/docker/cli/cli"
+	"github.com/docker/cli/cli/command"
+	"github.com/docker/cli/cli/config/configfile"
+	"github.com/docker/cli/cli/manifest/fetcher"
+	"github.com/docker/docker/pkg/homedir"
+	"github.com/docker/docker/registry"
+)
+
+type pushOpts struct {
+	newRef string
+	file   string
+	purge  bool
+}
+
+// YamlInput represents the YAML format input to the pushml
+// command.
+type YamlInput struct {
+	Image     string
+	Manifests []YamlManifestEntry
+}
+
+// YamlManifestEntry represents an entry in the list of manifests to
+// be combined into a manifest list, provided via the YAML input
+type YamlManifestEntry struct {
+	Image    string
+	Platform manifestlist.PlatformSpec
+}
+
+// we will store up a list of blobs we must ask the registry
+// to cross-mount into our target namespace
+type blobMount struct {
+	FromRepo reference.Named
+	Digest   digest.Digest
+}
+
+// if we have mounted blobs referenced from manifests from
+// outside the target repository namespace we will need to
+// push them to our target's repo as they will be references
+// from the final manifest list object we push
+type manifestPush struct {
+	Name      string
+	Digest    string
+	JSONBytes []byte
+	MediaType string
+}
+
+type manifestListPush struct {
+	targetRepoInfo    *registry.RepositoryInfo
+	targetRef         reference.Named
+	targetEndpoint    registry.APIEndpoint
+	targetName        string
+	list              manifestlist.ManifestList
+	mountRequests     []manifestPush
+	blobMountRequests []blobMount
+}
+
+func newPushListCommand(dockerCli command.Cli) *cobra.Command {
+
+	opts := pushOpts{}
+
+	cmd := &cobra.Command{
+		Use:   "push [newRef | --file pre-annotated-yaml] [--purge=false]",
+		Short: "Push a manifest list for an image to a repository",
+		Args:  checkArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return putManifestList(dockerCli, opts, args)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&opts.file, "file", "f", "", "Path to a file containing a manifest list and its annotated constituent manifests")
+	flags.BoolVarP(&opts.purge, "purge", "p", true, "After pushing, delete the user's locally-stored manifest list info")
+
+	return cmd
+}
+
+func putManifestList(dockerCli command.Cli, opts pushOpts, args []string) error {
+	var (
+		yamlInput                         YamlInput
+		initialRef                        string
+		listPush                          manifestListPush
+		fullTargetRef, targetRef, bareRef reference.Named
+		err                               error
+	)
+
+	if opts.file != "" {
+		yamlInput, err = getYamlInput(opts.file)
+		if err != nil {
+			return err
+		}
+		initialRef = yamlInput.Image
+	} else {
+		initialRef = args[0]
+	}
+
+	fullTargetRef, targetRef, bareRef, err = constructTargetRefs(initialRef)
+	if err != nil {
+		return err
+	}
+	logrus.Infof("beginning push of manifests into %s", fullTargetRef.String())
+
+	targetRepoInfo, err := registry.ParseRepositoryInfo(fullTargetRef)
+	if err != nil {
+		return errors.Wrapf(err, "error parsing repository name for manifest list (%s): %v", opts.newRef)
+	}
+	targetEndpoint, targetRepoName, err := setupRepo(targetRepoInfo)
+	if err != nil {
+		return errors.Wrapf(err, "error setting up repository endpoint and references for %q: %v", targetRef)
+	}
+	logrus.Debugf("creating target ref: %s", fullTargetRef.String())
+
+	ctx := context.Background()
+
+	// Now create the manifest list payload by looking up the manifest schemas
+	// for the constituent images:
+	logrus.Debugf("retrieving digests of images...")
+	if opts.file == "" {
+		listPush, err = listFromTransaction(targetRepoInfo, targetRepoName, fullTargetRef.String())
+	} else {
+		listPush, err = listFromYAML(dockerCli, fullTargetRef, targetRepoInfo, targetRepoName, yamlInput)
+	}
+	if err != nil {
+		return err
+	}
+
+	listPush.targetRepoInfo = targetRepoInfo
+	listPush.targetName = targetRepoName
+	listPush.targetRef = targetRef
+	listPush.targetEndpoint = targetEndpoint
+
+	err = doListPush(ctx, dockerCli, listPush, bareRef)
+	if err != nil {
+		return err
+	}
+	if opts.purge {
+		targetFilename, _ := mfToFilename(fullTargetRef.String(), "")
+		logrus.Debugf("deleting files at %s", targetFilename)
+		if err := os.RemoveAll(targetFilename); err != nil {
+			// Not a fatal error
+			logrus.Info("unable to clean up manifest files in %s", targetFilename)
+		}
+	}
+	return nil
+}
+
+func doListPush(ctx context.Context, dockerCli command.Cli, listPush manifestListPush, bareRef reference.Named) error {
+
+	targetURL := listPush.targetEndpoint.URL.String()
+	// Set the schema version
+	listPush.list.Versioned = manifestlist.SchemaVersion
+
+	urlBuilder, err := v2.NewURLBuilderFromString(targetURL, false)
+	logrus.Debugf("manifest: put: target endpoint url: %s", targetURL)
+	if err != nil {
+		return errors.Wrapf(err, "can't create URL builder from endpoint (%s): %v", targetURL)
+	}
+	pushURL, err := createManifestURLFromRef(listPush.targetRef, urlBuilder)
+	if err != nil {
+		return errors.Wrapf(err, "error setting up repository endpoint and references for %q: %v", listPush.targetRef)
+	}
+	logrus.Debugf("manifest list push url: %s", pushURL)
+
+	deserializedManifestList, err := manifestlist.FromDescriptors(listPush.list.Manifests)
+	if err != nil {
+		return errors.Wrap(err, "cannot deserialize manifest list")
+	}
+	mediaType, p, err := deserializedManifestList.Payload()
+	logrus.Debugf("mediaType of manifestList: %s", mediaType)
+	if err != nil {
+		return errors.Wrap(err, "cannot retrieve payload for HTTP PUT of manifest list")
+
+	}
+	putRequest, err := http.NewRequest("PUT", pushURL, bytes.NewReader(p))
+	if err != nil {
+		return errors.Wrap(err, "HTTP PUT request creation failed")
+	}
+	putRequest.Header.Set("Content-Type", mediaType)
+
+	tr, err := fetcher.GetDistClientTransport(ctx, dockerCli, listPush.targetRepoInfo, listPush.targetEndpoint, listPush.targetName)
+	if err != nil {
+		return errors.Wrap(err, "failed to setup HTTP client to repository")
+	}
+	httpClient := &http.Client{Transport: tr}
+
+	// before we push the manifest list, if we have any blob mount requests, we need
+	// to ask the registry to mount those blobs in our target so they are available
+	// as references
+	if err := mountBlobs(ctx, httpClient, targetURL, listPush.targetRef, listPush.blobMountRequests); err != nil {
+		return errors.Wrap(err, "couldn't mount blobs for cross-repository push")
+	}
+
+	// we also must push any manifests that are referenced in the manifest list into
+	// the target namespace
+	// Use the untagged target for this so the digest is used
+	// *could* i use targetRef instead of bareRef??
+	if err := pushReferences(httpClient, urlBuilder, bareRef, listPush.mountRequests); err != nil {
+		return errors.Wrap(err, "couldn't push manifests referenced in our manifest list")
+	}
+
+	resp, err := httpClient.Do(putRequest)
+	if err != nil {
+		return errors.Wrap(err, "v2 registry PUT of manifest list failed")
+	}
+	defer resp.Body.Close()
+
+	if statusSuccess(resp.StatusCode) {
+		dgstHeader := resp.Header.Get("Docker-Content-Digest")
+		dgst, err := digest.Parse(dgstHeader)
+		if err != nil {
+			return err
+		}
+		logrus.Infof("successfully pushed manifest list %s with digest %s", listPush.targetRef, dgst)
+		return nil
+	}
+	return fmt.Errorf("registry push unsuccessful: response %d: %s", resp.StatusCode, resp.Status)
+}
+
+func listFromTransaction(targetRepoInfo *registry.RepositoryInfo, targetRepoName, targetRef string) (manifestListPush, error) {
+	var (
+		manifestList      manifestlist.ManifestList
+		blobMountRequests []blobMount
+		manifestRequests  []manifestPush
+		listPush          manifestListPush
+		manifests         []string
+		err               error
+	)
+	if manifests, err = getListFilenames(targetRef); err != nil {
+		return listPush, err
+	}
+	// @TODO: Is this possible, or will manifests just be nil??
+	if len(manifests) == 0 {
+		return listPush, fmt.Errorf("%s not found", targetRef)
+	}
+	// manifests is a list of file paths
+	for _, manifestFile := range manifests {
+		fileParts := strings.Split(manifestFile, string(filepath.Separator))
+		numParts := len(fileParts)
+		mfstInspect, err := localManifestToManifestInspect(fileParts[numParts-1], fileParts[numParts-2])
+		if err != nil {
+			return listPush, err
+		}
+		if mfstInspect.Architecture == "" || mfstInspect.OS == "" {
+			return listPush, fmt.Errorf("malformed manifest object. cannot push to registry")
+		}
+		// @TODO: Why am I getting another repoInfo here?
+		manifest, repoInfo, err := buildManifestObj(targetRepoInfo, mfstInspect)
+		if err != nil {
+			return listPush, err
+		}
+		manifestList.Manifests = append(manifestList.Manifests, manifest)
+
+		// if this image is in a different repo, we need to add the layer/blob digests to the list of
+		// requested blob mounts (cross-repository push) before pushing the manifest list
+		// @TODO: Test pushing manifest list where targetRepoName == manifestRepoName for all manifests
+		manifestRepoName := reference.Path(repoInfo.Name)
+		if targetRepoName != manifestRepoName {
+			bmr, mr := buildBlobMountRequestLists(mfstInspect, targetRepoInfo.Name, repoInfo.Name)
+			blobMountRequests = append(blobMountRequests, bmr...)
+			manifestRequests = append(manifestRequests, mr...)
+		}
+	}
+	listPush.mountRequests = manifestRequests
+	listPush.blobMountRequests = blobMountRequests
+	listPush.list = manifestList
+
+	return listPush, nil
+}
+
+func listFromYAML(dockerCli command.Cli, targetRef reference.Named, targetRepoInfo *registry.RepositoryInfo, targetRepoName string, yamlInput YamlInput) (manifestListPush, error) {
+	var (
+		manifestList      manifestlist.ManifestList
+		blobMountRequests []blobMount
+		manifestRequests  []manifestPush
+		listPush          manifestListPush
+	)
+	for _, mfEntry := range yamlInput.Manifests {
+		mfstInspects, repoInfo, err := getImageData(dockerCli, mfEntry.Image, targetRef.Name(), true)
+		if err != nil {
+			return listPush, err
+		}
+		if len(mfstInspects) == 0 {
+			return listPush, fmt.Errorf("manifest %s not found", mfEntry.Image)
+		}
+		mfstInspect := mfstInspects[0]
+		if mfstInspect.Architecture == "" || mfstInspect.OS == "" {
+			return listPush, fmt.Errorf("malformed manifest object. cannot push to registry")
+		}
+		manifest, repoInfo, err := buildManifestObj(targetRepoInfo, mfstInspect)
+		if err != nil {
+			return listPush, err
+		}
+		manifestList.Manifests = append(manifestList.Manifests, manifest)
+
+		// if this image is in a different repo, we need to add the layer/blob digests to the list of
+		// requested blob mounts (cross-repository push) before pushing the manifest list
+		manifestRepoName := reference.Path(repoInfo.Name)
+		if targetRepoName != manifestRepoName {
+			bmr, mr := buildBlobMountRequestLists(mfstInspect, targetRepoInfo.Name, repoInfo.Name)
+			blobMountRequests = append(blobMountRequests, bmr...)
+			manifestRequests = append(manifestRequests, mr...)
+
+		}
+	}
+	listPush.mountRequests = manifestRequests
+	listPush.blobMountRequests = blobMountRequests
+	listPush.list = manifestList
+	return listPush, nil
+}
+
+func constructTargetRefs(initialRef string) (reference.Named, reference.Named, reference.Named, error) {
+	var (
+		targetRefNoDomain reference.Named
+		targetRefNoTag    reference.Named
+		fullTargetRef     reference.Named
+		err               error
+	)
+
+	fullTargetRef, err = reference.ParseNormalizedNamed(initialRef)
+	if err != nil {
+		return nil, nil, nil, errors.Wrapf(err, "error parsing name for manifest list (%s): %v")
+	}
+	if _, isDigested := fullTargetRef.(reference.Canonical); !isDigested {
+		fullTargetRef = reference.TagNameOnly(fullTargetRef)
+	}
+	tagIndex := strings.LastIndex(fullTargetRef.String(), ":")
+	logrus.Debugf("fullTargetRef. should be complete by now: %s", fullTargetRef.String())
+	if tagIndex < 0 {
+		return nil, nil, nil, fmt.Errorf("malformed reference")
+	}
+	tag := fullTargetRef.String()[tagIndex+1:]
+	targetRefNoTag, err = reference.WithName(reference.Path(fullTargetRef))
+	logrus.Debugf("targetRefNoTag should have no name and no tag: %s", targetRefNoTag.String())
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	targetRefNoDomain, _ = reference.WithTag(targetRefNoTag, tag)
+	logrus.Debugf("targetRefNoDomain should have no domain but a tag? %s", targetRefNoDomain.String())
+
+	return fullTargetRef, targetRefNoDomain, targetRefNoTag, nil
+}
+
+func getYamlInput(yamlFile string) (YamlInput, error) {
+	logrus.Debugf("YAML file: %s", yamlFile)
+
+	if _, err := os.Stat(yamlFile); err != nil {
+		logrus.Debugf("unable to open file: %s", yamlFile)
+	}
+
+	var yamlInput YamlInput
+	yamlBuf, err := ioutil.ReadFile(yamlFile)
+	if err != nil {
+		return YamlInput{}, errors.Wrapf(err, "can't read YAML file %s", yamlFile)
+	}
+	if err = yaml.Unmarshal(yamlBuf, &yamlInput); err != nil {
+		return YamlInput{}, errors.Wrapf(err, "can't unmarshal YAML file %s", yamlFile)
+	}
+	return yamlInput, nil
+}
+
+func buildManifestObj(targetRepo *registry.RepositoryInfo, mfInspect fetcher.ImgManifestInspect) (manifestlist.ManifestDescriptor, *registry.RepositoryInfo, error) {
+
+	manifestRef, err := reference.ParseNormalizedNamed(mfInspect.RefName)
+	if err != nil {
+		return manifestlist.ManifestDescriptor{}, nil, err
+	}
+	repoInfo, err := registry.ParseRepositoryInfo(manifestRef)
+	if err != nil {
+		return manifestlist.ManifestDescriptor{}, nil, err
+	}
+
+	manifestRepoHostname := reference.Domain(repoInfo.Name)
+	targetRepoHostname := reference.Domain(targetRepo.Name)
+	if manifestRepoHostname != targetRepoHostname {
+		return manifestlist.ManifestDescriptor{}, nil, fmt.Errorf("cannot use source images from a different registry than the target image: %s != %s", manifestRepoHostname, targetRepoHostname)
+	}
+
+	manifest := manifestlist.ManifestDescriptor{
+		Platform: manifestlist.PlatformSpec{
+			Architecture: mfInspect.Architecture,
+			OS:           mfInspect.OS,
+			OSVersion:    mfInspect.OSVersion,
+			OSFeatures:   mfInspect.OSFeatures,
+			Variant:      mfInspect.Variant,
+			Features:     mfInspect.Features,
+		},
+	}
+	manifest.Descriptor.Digest = mfInspect.Digest
+	manifest.Size = mfInspect.Size
+	manifest.MediaType = mfInspect.MediaType
+
+	err = manifest.Descriptor.Digest.Validate()
+	if err != nil {
+		return manifestlist.ManifestDescriptor{}, nil, errors.Wrapf(err, "Digest parse of image %q failed with error: %v", manifestRef)
+	}
+
+	return manifest, repoInfo, nil
+}
+
+func buildBlobMountRequestLists(mfstInspect fetcher.ImgManifestInspect, targetRepoName, mfRepoName reference.Named) ([]blobMount, []manifestPush) {
+
+	var (
+		blobMountRequests []blobMount
+		manifestRequests  []manifestPush
+	)
+
+	logrus.Debugf("adding manifest references of %q to blob mount requests to %s", mfRepoName, targetRepoName)
+	for _, layer := range mfstInspect.References {
+		dgst, _ := digest.Parse(layer)
+		blobMountRequests = append(blobMountRequests, blobMount{FromRepo: targetRepoName, Digest: dgst})
+	}
+	// also must add the manifest to be pushed in the target namespace
+	logrus.Debugf("adding manifest %q -> to be pushed to %q as a manifest reference", mfRepoName, targetRepoName)
+	manifestRequests = append(manifestRequests, manifestPush{
+		Name:      mfRepoName.String(),
+		Digest:    mfstInspect.Digest.String(),
+		JSONBytes: mfstInspect.CanonicalJSON,
+		MediaType: mfstInspect.MediaType,
+	})
+	return blobMountRequests, manifestRequests
+}
+
+func createManifestURLFromRef(targetRef reference.Named, urlBuilder *v2.URLBuilder) (string, error) {
+
+	manifestURL, err := urlBuilder.BuildManifestURL(targetRef)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to build manifest URL from target reference")
+	}
+	return manifestURL, nil
+}
+
+func setupRepo(repoInfo *registry.RepositoryInfo) (registry.APIEndpoint, string, error) {
+	endpoint, err := selectPushEndpoint(repoInfo)
+	if err != nil {
+		return endpoint, "", err
+	}
+	repoName := repoInfo.Name.Name()
+	// If endpoint does not support CanonicalName, use the RemoteName instead
+	if endpoint.TrimHostname {
+		repoName = reference.Path(repoInfo.Name)
+	}
+	return endpoint, repoName, nil
+}
+
+func selectPushEndpoint(repoInfo *registry.RepositoryInfo) (registry.APIEndpoint, error) {
+	var err error
+
+	options := registry.ServiceOptions{}
+	// By default (unless deprecated), loopback (IPv4 at least...) is automatically added as an insecure registry.
+	options.InsecureRegistries, err = loadLocalInsecureRegistries()
+	if err != nil {
+		return registry.APIEndpoint{}, err
+	}
+	registryService := registry.NewService(options)
+	endpoints, err := registryService.LookupPushEndpoints(reference.Domain(repoInfo.Name))
+	if err != nil {
+		return registry.APIEndpoint{}, err
+	}
+	// Default to the highest priority endpoint to return
+	endpoint := endpoints[0]
+	if !repoInfo.Index.Secure {
+		for _, ep := range endpoints {
+			if ep.URL.Scheme == "http" {
+				endpoint = ep
+			}
+		}
+	}
+	return endpoint, nil
+}
+
+func loadLocalInsecureRegistries() ([]string, error) {
+	insecureRegistries := []string{}
+	// Check $HOME/.docker/config.json. There may be mismatches between what the user has in their
+	// local config and what the daemon they're talking to allows, but we can be okay with that.
+	userHome, err := homedir.GetStatic()
+	if err != nil {
+		return []string{}, fmt.Errorf("manifest create: lookup local insecure registries: Unable to retrieve $HOME")
+	}
+
+	jsonData, err := ioutil.ReadFile(filepath.Join(userHome, ".docker/config.json"))
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return []string{}, errors.Wrap(err, "manifest create:")
+		}
+		// If the file just doesn't exist, no insecure registries were specified.
+		logrus.Debug("manifest: no insecure registries were specified via $HOME/.docker/config.json")
+		return []string{}, nil
+	}
+
+	if jsonData != nil {
+		cf := configfile.ConfigFile{}
+		if err := json.Unmarshal(jsonData, &cf); err != nil {
+			logrus.Debugf("manifest create: unable to unmarshal insecure registries from $HOME/.docker/config.json: %s", err)
+			return []string{}, nil
+		}
+		if cf.InsecureRegistries == nil {
+			return []string{}, nil
+		}
+		// @TODO: Add tests for a) specifying in config.json, b) invalid entries
+		for _, reg := range cf.InsecureRegistries {
+			if err := net.ParseIP(reg); err == nil {
+				insecureRegistries = append(insecureRegistries, reg)
+			} else if _, _, err := net.ParseCIDR(reg); err == nil {
+				insecureRegistries = append(insecureRegistries, reg)
+			} else if ips, err := net.LookupHost(reg); err == nil {
+				insecureRegistries = append(insecureRegistries, ips...)
+			} else {
+				return []string{}, errors.Wrapf(err, "manifest create: Invalid registry (%s) specified in ~/.docker/config.json: %s", reg)
+			}
+		}
+	}
+
+	return insecureRegistries, nil
+}
+
+func pushReferences(httpClient *http.Client, urlBuilder *v2.URLBuilder, ref reference.Named, manifests []manifestPush) error {
+	for _, manifest := range manifests {
+		dgst, err := digest.Parse(manifest.Digest)
+		if err != nil {
+			return errors.Wrapf(err, "error parsing manifest digest (%s) for referenced manifest %q: %v", manifest.Digest, manifest.Name)
+		}
+		targetRef, err := reference.WithDigest(ref, dgst)
+		if err != nil {
+			return errors.Wrapf(err, "error creating manifest digest target for referenced manifest %q: %v", manifest.Name)
+		}
+		pushURL, err := urlBuilder.BuildManifestURL(targetRef)
+		if err != nil {
+			return errors.Wrapf(err, "error setting up manifest push URL for manifest references for %q: %v", manifest.Name)
+		}
+
+		pushRequest, err := http.NewRequest("PUT", pushURL, bytes.NewReader(manifest.JSONBytes))
+		if err != nil {
+			return errors.Wrap(err, "HTTP PUT request creation for manifest reference push failed")
+		}
+		pushRequest.Header.Set("Content-Type", manifest.MediaType)
+		resp, err := httpClient.Do(pushRequest)
+		if err != nil {
+			return errors.Wrap(err, "PUT of manifest reference failed")
+		}
+
+		resp.Body.Close()
+		if !statusSuccess(resp.StatusCode) {
+			return fmt.Errorf("referenced manifest push unsuccessful: response %d: %s", resp.StatusCode, resp.Status)
+		}
+		dgstHeader := resp.Header.Get("Docker-Content-Digest")
+		dgstResult, err := digest.Parse(dgstHeader)
+		if err != nil {
+			return errors.Wrap(err, "couldn't parse pushed manifest digest response")
+		}
+		logrus.Infof("pushed manifest (%s) digest:  %s", manifest.Name, string(dgstResult))
+	}
+	return nil
+}
+
+func mountBlobs(ctx context.Context, httpClient *http.Client, targetURL string, ref reference.Named, blobsRequested []blobMount) error {
+	for _, blob := range blobsRequested {
+		repo, err := client.NewRepository(ctx, ref, targetURL, httpClient.Transport)
+		if err != nil {
+			return err
+		}
+		bs := repo.Blobs(ctx)
+		fromCanonical, err := reference.WithDigest(blob.FromRepo, blob.Digest)
+		if err != nil {
+			return err
+		}
+		lu, err := bs.Create(ctx, client.WithMountFrom(fromCanonical))
+		if err != nil {
+			if _, ok := err.(distribution.ErrBlobMounted); ok {
+				// mount successful
+			}
+		} else {
+			// registry treated this as a normal upload
+			lu.Cancel(ctx)
+		}
+		logrus.Debugf("mount of blob %s succeeded", blob.Digest.String())
+	}
+	return nil
+}
+
+func checkArgs(cmd *cobra.Command, args []string) error {
+	useErr := fmt.Errorf("Incorrect command format.\n Usage: %s", cmd.Use)
+	numArgs := len(args)
+	if numArgs > 1 {
+		return useErr
+	}
+	fileFlag := cmd.Flags().Lookup("file")
+	if fileFlag.Changed && numArgs != 0 {
+		return useErr
+	}
+	if !fileFlag.Changed && numArgs == 0 {
+		return useErr
+	}
+	purgeFlag := cmd.Flags().Lookup("purge")
+	if purgeFlag.Changed && fileFlag.Changed {
+		return fmt.Errorf("using '--purge' doesn't make sense with '--file'")
+	}
+	return nil
+}
+
+func statusSuccess(status int) bool {
+	return status >= 200 && status <= 399
+}

--- a/cli/command/manifest/util.go
+++ b/cli/command/manifest/util.go
@@ -1,0 +1,179 @@
+package manifest
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/docker/cli/cli/manifest/fetcher"
+	"github.com/docker/docker/pkg/homedir"
+)
+
+type osArch struct {
+	os   string
+	arch string
+}
+
+// dirOpenError
+type dirOpenError struct {
+}
+
+func (e dirOpenError) Error() string {
+	return "cannot perform open on a directory"
+}
+
+// Remove any unsupported os/arch combo
+// list of valid os/arch values (see "Optional Environment Variables" section
+// of https://golang.org/doc/install/source
+// Added linux/s390x as we know System z support already exists
+var validOSArches = map[osArch]bool{
+	{os: "darwin", arch: "386"}:      true,
+	{os: "darwin", arch: "amd64"}:    true,
+	{os: "darwin", arch: "arm"}:      true,
+	{os: "darwin", arch: "arm64"}:    true,
+	{os: "dragonfly", arch: "amd64"}: true,
+	{os: "freebsd", arch: "386"}:     true,
+	{os: "freebsd", arch: "amd64"}:   true,
+	{os: "freebsd", arch: "arm"}:     true,
+	{os: "linux", arch: "386"}:       true,
+	{os: "linux", arch: "amd64"}:     true,
+	{os: "linux", arch: "arm"}:       true,
+	{os: "linux", arch: "arm64"}:     true,
+	{os: "linux", arch: "ppc64le"}:   true,
+	{os: "linux", arch: "mips64"}:    true,
+	{os: "linux", arch: "mips64le"}:  true,
+	{os: "linux", arch: "s390x"}:     true,
+	{os: "netbsd", arch: "386"}:      true,
+	{os: "netbsd", arch: "amd64"}:    true,
+	{os: "netbsd", arch: "arm"}:      true,
+	{os: "openbsd", arch: "386"}:     true,
+	{os: "openbsd", arch: "amd64"}:   true,
+	{os: "openbsd", arch: "arm"}:     true,
+	{os: "plan9", arch: "386"}:       true,
+	{os: "plan9", arch: "amd64"}:     true,
+	{os: "solaris", arch: "amd64"}:   true,
+	{os: "windows", arch: "386"}:     true,
+	{os: "windows", arch: "amd64"}:   true,
+}
+
+func isValidOSArch(os string, arch string) bool {
+	// check for existence of this combo
+	_, ok := validOSArches[osArch{os, arch}]
+	return ok
+}
+
+func makeFilesafeName(ref string) string {
+	// Make sure the ref is a normalized name before calling this func
+	fileName := strings.Replace(ref, ":", "-", -1)
+	return strings.Replace(fileName, "/", "_", -1)
+}
+
+func getListFilenames(transaction string) ([]string, error) {
+	baseDir, err := buildBaseFilename()
+	if err != nil {
+		return nil, err
+	}
+	transactionDir := filepath.Join(baseDir, makeFilesafeName(transaction))
+	fd, err := os.Open(transactionDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	fileNames, err := fd.Readdirnames(-1)
+	if err != nil {
+		return nil, err
+	}
+	fd.Close()
+	for i, f := range fileNames {
+		fileNames[i] = filepath.Join(transactionDir, f)
+	}
+	return fileNames, nil
+}
+
+func getManifestFd(manifest, transaction string) (*os.File, error) {
+
+	fileName, err := mfToFilename(manifest, transaction)
+	if err != nil {
+		return nil, err
+	}
+
+	return getFdGeneric(fileName)
+}
+
+func getFdGeneric(file string) (*os.File, error) {
+	fileinfo, err := os.Stat(file)
+	if err != nil && os.IsNotExist(err) {
+		return nil, nil
+	} else if err != nil {
+		return nil, err
+	}
+	if fileinfo.IsDir() {
+		return nil, dirOpenError{}
+	}
+	fd, err := os.OpenFile(file, os.O_RDWR|os.O_CREATE, 0600)
+	if err != nil {
+		return nil, err
+	}
+	return fd, nil
+}
+
+func buildBaseFilename() (string, error) {
+	// Get will check for $HOME and if not set, lookup a user in
+	// a static-safe way (without calling os/user.Current())
+	userHome := homedir.Get()
+	return filepath.Join(userHome, ".docker", "manifests"), nil
+}
+
+func mfToFilename(manifest, transaction string) (string, error) {
+
+	baseDir, err := buildBaseFilename()
+	if err != nil {
+		return "", nil
+	}
+	return filepath.Join(baseDir, makeFilesafeName(transaction), makeFilesafeName(manifest)), nil
+}
+
+func localManifestToManifestInspect(manifest, transaction string) (fetcher.ImgManifestInspect, error) {
+
+	var newMI fetcher.ImgManifestInspect
+	filename, err := mfToFilename(manifest, transaction)
+	if err != nil {
+		return newMI, err
+	}
+	buf, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return newMI, err
+	}
+	if err := json.Unmarshal(buf, &newMI); err != nil {
+		return newMI, err
+	}
+	return newMI, nil
+}
+
+func updateMfFile(newMI fetcher.ImgManifestInspect, mfName, transaction string) error {
+	fileName, err := mfToFilename(mfName, transaction)
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(fileName); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	fd, err := os.Create(fileName)
+	if err != nil {
+		return err
+	}
+	defer fd.Close()
+	theBytes, err := json.Marshal(newMI)
+	if err != nil {
+		return err
+	}
+
+	if _, err := fd.Write(theBytes); err != nil {
+		return err
+	}
+	return nil
+}

--- a/cli/command/manifest/util.go
+++ b/cli/command/manifest/util.go
@@ -1,27 +1,12 @@
 package manifest
 
 import (
-	"encoding/json"
-	"io/ioutil"
-	"os"
-	"path/filepath"
-	"strings"
-
-	"github.com/docker/cli/cli/manifest/fetcher"
-	"github.com/docker/docker/pkg/homedir"
+	"github.com/docker/distribution/reference"
 )
 
 type osArch struct {
 	os   string
 	arch string
-}
-
-// dirOpenError
-type dirOpenError struct {
-}
-
-func (e dirOpenError) Error() string {
-	return "cannot perform open on a directory"
 }
 
 // Remove any unsupported os/arch combo
@@ -64,116 +49,13 @@ func isValidOSArch(os string, arch string) bool {
 	return ok
 }
 
-func makeFilesafeName(ref string) string {
-	// Make sure the ref is a normalized name before calling this func
-	fileName := strings.Replace(ref, ":", "-", -1)
-	return strings.Replace(fileName, "/", "_", -1)
-}
-
-func getListFilenames(transaction string) ([]string, error) {
-	baseDir, err := buildBaseFilename()
+func normalizeReference(ref string) (reference.Named, error) {
+	namedRef, err := reference.ParseNormalizedNamed(ref)
 	if err != nil {
 		return nil, err
 	}
-	transactionDir := filepath.Join(baseDir, makeFilesafeName(transaction))
-	fd, err := os.Open(transactionDir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, err
+	if _, isDigested := namedRef.(reference.Canonical); !isDigested {
+		return reference.TagNameOnly(namedRef), nil
 	}
-	fileNames, err := fd.Readdirnames(-1)
-	if err != nil {
-		return nil, err
-	}
-	fd.Close()
-	for i, f := range fileNames {
-		fileNames[i] = filepath.Join(transactionDir, f)
-	}
-	return fileNames, nil
-}
-
-func getManifestFd(manifest, transaction string) (*os.File, error) {
-
-	fileName, err := mfToFilename(manifest, transaction)
-	if err != nil {
-		return nil, err
-	}
-
-	return getFdGeneric(fileName)
-}
-
-func getFdGeneric(file string) (*os.File, error) {
-	fileinfo, err := os.Stat(file)
-	if err != nil && os.IsNotExist(err) {
-		return nil, nil
-	} else if err != nil {
-		return nil, err
-	}
-	if fileinfo.IsDir() {
-		return nil, dirOpenError{}
-	}
-	fd, err := os.OpenFile(file, os.O_RDWR|os.O_CREATE, 0600)
-	if err != nil {
-		return nil, err
-	}
-	return fd, nil
-}
-
-func buildBaseFilename() (string, error) {
-	// Get will check for $HOME and if not set, lookup a user in
-	// a static-safe way (without calling os/user.Current())
-	userHome := homedir.Get()
-	return filepath.Join(userHome, ".docker", "manifests"), nil
-}
-
-func mfToFilename(manifest, transaction string) (string, error) {
-
-	baseDir, err := buildBaseFilename()
-	if err != nil {
-		return "", nil
-	}
-	return filepath.Join(baseDir, makeFilesafeName(transaction), makeFilesafeName(manifest)), nil
-}
-
-func localManifestToManifestInspect(manifest, transaction string) (fetcher.ImgManifestInspect, error) {
-
-	var newMI fetcher.ImgManifestInspect
-	filename, err := mfToFilename(manifest, transaction)
-	if err != nil {
-		return newMI, err
-	}
-	buf, err := ioutil.ReadFile(filename)
-	if err != nil {
-		return newMI, err
-	}
-	if err := json.Unmarshal(buf, &newMI); err != nil {
-		return newMI, err
-	}
-	return newMI, nil
-}
-
-func updateMfFile(newMI fetcher.ImgManifestInspect, mfName, transaction string) error {
-	fileName, err := mfToFilename(mfName, transaction)
-	if err != nil {
-		return err
-	}
-	if err := os.Remove(fileName); err != nil && !os.IsNotExist(err) {
-		return err
-	}
-	fd, err := os.Create(fileName)
-	if err != nil {
-		return err
-	}
-	defer fd.Close()
-	theBytes, err := json.Marshal(newMI)
-	if err != nil {
-		return err
-	}
-
-	if _, err := fd.Write(theBytes); err != nil {
-		return err
-	}
-	return nil
+	return namedRef, nil
 }

--- a/cli/config/configfile/file.go
+++ b/cli/config/configfile/file.go
@@ -43,6 +43,7 @@ type ConfigFile struct {
 	NodesFormat          string                      `json:"nodesFormat,omitempty"`
 	PruneFilters         []string                    `json:"pruneFilters,omitempty"`
 	Proxies              map[string]ProxyConfig      `json:"proxies,omitempty"`
+	InsecureRegistries   []string                    `json:"insecure-registries,omitempty"`
 }
 
 // ProxyConfig contains proxy configuration settings

--- a/cli/internal/test/cli.go
+++ b/cli/internal/test/cli.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/cli/cli/config/configfile"
 	"github.com/docker/cli/cli/config/credentials"
+	manifeststore "github.com/docker/cli/cli/manifest/store"
 	"github.com/docker/docker/client"
 )
 
@@ -78,4 +79,10 @@ func (c *FakeCli) CredentialsStore(serverAddress string) credentials.Store {
 		c.store = NewFakeStore()
 	}
 	return c.store
+}
+
+// ManifestStore returns a fake store used for testing
+func (c *FakeCli) ManifestStore() manifeststore.Store {
+	// TODO: use a fake store when a test requires it
+	return nil
 }

--- a/cli/manifest/fetcher/fetcher.go
+++ b/cli/manifest/fetcher/fetcher.go
@@ -1,0 +1,446 @@
+package fetcher
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"runtime"
+	"time"
+
+	"golang.org/x/net/context"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/pkg/errors"
+
+	"github.com/docker/cli/cli/command"
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/manifest/manifestlist"
+	"github.com/docker/distribution/manifest/schema2"
+	"github.com/docker/distribution/reference"
+	"github.com/docker/distribution/registry/api/errcode"
+	"github.com/docker/distribution/registry/api/v2"
+	"github.com/docker/distribution/registry/client"
+	"github.com/docker/distribution/registry/client/auth"
+	"github.com/docker/distribution/registry/client/transport"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/dockerversion"
+	"github.com/docker/docker/registry"
+	digest "github.com/opencontainers/go-digest"
+)
+
+// ManifestFetcher is to retrieve manifest and image info for an image or manifest list
+type ManifestFetcher struct {
+	endpoint   registry.APIEndpoint
+	repoInfo   *registry.RepositoryInfo
+	repo       distribution.Repository
+	authConfig types.AuthConfig
+	service    registry.Service
+}
+
+type manifestInfo struct {
+	blobDigests []digest.Digest
+	layers      []string
+	digest      digest.Digest
+	platform    manifestlist.PlatformSpec
+	length      int64
+	jsonBytes   []byte
+}
+
+type manifestListInspect struct {
+	imageInfos []*Image
+	mfInfos    []manifestInfo
+	mediaTypes []string
+}
+
+// NewManifestFetcher builds a ManifestFetcher for use with a specific registry
+func NewManifestFetcher(endpoint registry.APIEndpoint, repoInfo *registry.RepositoryInfo, authConfig types.AuthConfig, registryService registry.Service) (ManifestFetcher, error) {
+	switch endpoint.Version {
+	case registry.APIVersion2:
+		return ManifestFetcher{
+			endpoint: endpoint, authConfig: authConfig,
+			service:  registryService,
+			repoInfo: repoInfo,
+		}, nil
+	case registry.APIVersion1:
+		return ManifestFetcher{}, fmt.Errorf("v1 registries are no longer supported")
+	}
+	return ManifestFetcher{}, fmt.Errorf("unknown version %d for registry %s", endpoint.Version, endpoint.URL)
+}
+
+// Fetch gets the summarized information for an image or manifest list
+func (mf *ManifestFetcher) Fetch(ctx context.Context, dockerCli command.Cli, ref reference.Named) ([]ImgManifestInspect, error) {
+	// Pre-condition: ref has to be tagged (e.g. using ParseNormalizedNamed)
+	var err error
+
+	mf.repo, err = newV2Repository(ctx, dockerCli, mf.repoInfo, mf.endpoint)
+	if err != nil {
+		logrus.Debugf("Error getting v2 registry: %v", err)
+		return nil, err
+	}
+
+	images, err := mf.fetchWithRepository(ctx, ref)
+	if err != nil {
+		if continueOnError(err) {
+			return nil, RecoverableError{original: err}
+		}
+		return nil, err
+	}
+	for _, img := range images {
+		img.MediaType = schema2.MediaTypeManifest
+	}
+	return images, err
+}
+
+func (mf *ManifestFetcher) fetchWithRepository(ctx context.Context, ref reference.Named) ([]ImgManifestInspect, error) {
+	var (
+		manifest    distribution.Manifest
+		tagOrDigest string // Used for logging/progress only
+		tagList     []string
+		imageList   []ImgManifestInspect
+	)
+
+	manSvc, err := mf.repo.Manifests(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if tagged, isTagged := ref.(reference.NamedTagged); isTagged {
+		manifest, err = manSvc.Get(ctx, "", distribution.WithTag(tagged.Tag()))
+		if err != nil {
+			return nil, err
+		}
+		tagOrDigest = tagged.Tag()
+	} else if digested, isDigested := ref.(reference.Canonical); isDigested {
+		manifest, err = manSvc.Get(ctx, digested.Digest())
+		if err != nil {
+			return nil, err
+		}
+		tagOrDigest = digested.Digest().String()
+	} else {
+		return nil, fmt.Errorf("internal error: reference has neither a tag nor a digest: %s", ref.String())
+	}
+
+	if manifest == nil {
+		return nil, fmt.Errorf("image manifest does not exist for tag or digest %q", tagOrDigest)
+	}
+
+	tagList, err = mf.repo.Tags(ctx).All(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var (
+		images    []*Image
+		mfInfos   []manifestInfo
+		mediaType []string
+	)
+
+	switch v := manifest.(type) {
+	// Removed Schema 1 support
+	case *schema2.DeserializedManifest:
+		image, mfInfo, err := mf.pullSchema2(ctx, ref, *v)
+		images = append(images, image)
+		mfInfos = append(mfInfos, mfInfo)
+		mediaType = append(mediaType, schema2.MediaTypeManifest)
+		if err != nil {
+			return nil, err
+		}
+	case *manifestlist.DeserializedManifestList:
+		listInspect, err := mf.pullManifestList(ctx, ref, *v)
+		if err != nil {
+			return nil, err
+		}
+		images = listInspect.imageInfos
+		mfInfos = listInspect.mfInfos
+		mediaType = listInspect.mediaTypes
+	default:
+		return nil, fmt.Errorf("unsupported manifest format: %v", v)
+	}
+
+	for idx, img := range images {
+		imgReturn := makeImgManifestInspect(ref.String(), img, tagOrDigest, mfInfos[idx], mediaType[idx], tagList)
+		imageList = append(imageList, *imgReturn)
+	}
+	return imageList, nil
+}
+
+func (mf *ManifestFetcher) pullSchema2(ctx context.Context, ref reference.Named, mfst schema2.DeserializedManifest) (*Image, manifestInfo, error) {
+	var (
+		img *Image
+	)
+
+	mfDigest, err := schema2ManifestDigest(ref, mfst)
+	if err != nil {
+		return nil, manifestInfo{}, err
+	}
+	mfInfo := manifestInfo{
+		digest: mfDigest}
+
+	// Pull the image config
+	configJSON, err := mf.pullSchema2ImageConfig(ctx, mfst.Target().Digest)
+	if err != nil {
+		return nil, mfInfo, err
+	}
+
+	img, err = NewImageFromJSON(configJSON)
+	if err != nil {
+		return nil, mfInfo, err
+	}
+	if runtime.GOOS == "windows" {
+		if img.RootFS == nil {
+			return nil, mfInfo, errors.New("image config has no rootfs section")
+		}
+	}
+
+	for _, descriptor := range mfst.References() {
+		mfInfo.blobDigests = append(mfInfo.blobDigests, descriptor.Digest)
+	}
+	for _, layer := range mfst.Layers {
+		mfInfo.layers = append(mfInfo.layers, layer.Digest.String())
+	}
+
+	// add the size of the manifest to the image response; needed for assembling proper
+	// manifest lists
+	_, mfBytes, err := mfst.Payload()
+	if err != nil {
+		return nil, mfInfo, err
+	}
+	mfInfo.length = int64(len(mfBytes))
+	mfInfo.jsonBytes = mfBytes
+	mfInfo.platform = manifestlist.PlatformSpec{
+		OS:           img.OS,
+		Architecture: img.Architecture,
+		OSVersion:    img.OSVersion,
+		OSFeatures:   img.OSFeatures,
+	}
+	return img, mfInfo, nil
+}
+
+func (mf *ManifestFetcher) pullSchema2ImageConfig(ctx context.Context, dgst digest.Digest) ([]byte, error) {
+	blobs := mf.repo.Blobs(ctx)
+	configJSON, err := blobs.Get(ctx, dgst)
+	if err != nil {
+		return nil, err
+	}
+
+	// Verify image config digest
+	verifier := dgst.Verifier()
+	if err != nil {
+		return nil, err
+	}
+	if _, err := verifier.Write(configJSON); err != nil {
+		return nil, err
+	}
+	if !verifier.Verified() {
+		err := fmt.Errorf("image config verification failed for digest %s", dgst)
+		return nil, err
+	}
+
+	return configJSON, nil
+}
+
+// schema2ManifestDigest computes the manifest digest, and, if pulling by
+// digest, ensures that it matches the requested digest.
+func schema2ManifestDigest(ref reference.Named, mfst distribution.Manifest) (digest.Digest, error) {
+	_, canonical, err := mfst.Payload()
+	if err != nil {
+		return "", err
+	}
+
+	// If pull by digest, then verify the manifest digest.
+	if digested, isDigested := ref.(reference.Canonical); isDigested {
+		verifier := digested.Digest().Verifier()
+		if err != nil {
+			return "", err
+		}
+		if _, err := verifier.Write(canonical); err != nil {
+			return "", err
+		}
+		if !verifier.Verified() {
+			err := fmt.Errorf("manifest verification failed for digest %s", digested.Digest())
+			return "", err
+		}
+		return digested.Digest(), nil
+	}
+
+	return digest.FromBytes(canonical), nil
+}
+
+// pullManifestList handles "manifest lists" which point to various
+// platform-specifc manifests.
+func (mf *ManifestFetcher) pullManifestList(ctx context.Context, ref reference.Named, mfstList manifestlist.DeserializedManifestList) (*manifestListInspect, error) {
+	var (
+		imageList = []*Image{}
+		mfInfos   = []manifestInfo{}
+		mediaType = []string{}
+		v         *schema2.DeserializedManifest
+		ok        bool
+	)
+	manifestListDigest, err := schema2ManifestDigest(ref, mfstList)
+	if err != nil {
+		return nil, err
+	}
+	logrus.Debugf("Pulling manifest list entries for ML digest %v", manifestListDigest)
+
+	for _, manifestDescriptor := range mfstList.Manifests {
+		manSvc, err := mf.repo.Manifests(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		manifest, err := manSvc.Get(ctx, manifestDescriptor.Digest)
+		if err != nil {
+			return nil, err
+		}
+
+		manifestRef, err := reference.WithDigest(ref, manifestDescriptor.Digest)
+		if err != nil {
+			return nil, err
+		}
+
+		if v, ok = manifest.(*schema2.DeserializedManifest); !ok {
+			return nil, fmt.Errorf("unsupported manifest format: %s", v)
+		}
+		img, mfInfo, err := mf.pullSchema2(ctx, manifestRef, *v)
+		if err != nil {
+			return nil, err
+		}
+		imageList = append(imageList, img)
+		mfInfo.platform = manifestDescriptor.Platform
+		mfInfos = append(mfInfos, mfInfo)
+		mediaType = append(mediaType, schema2.MediaTypeManifest)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &manifestListInspect{imageInfos: imageList, mfInfos: mfInfos, mediaTypes: mediaType}, err
+}
+
+func newV2Repository(ctx context.Context, dockerCli command.Cli, repoInfo *registry.RepositoryInfo, endpoint registry.APIEndpoint) (distribution.Repository, error) {
+	repoName := repoInfo.Name.Name()
+	// If endpoint does not support CanonicalName, use the RemoteName instead
+	if endpoint.TrimHostname {
+		repoName = reference.Path(repoInfo.Name)
+	}
+	repoNameRef, err := reference.WithName(repoName)
+	if err != nil {
+		return nil, err
+	}
+
+	tr, err := GetDistClientTransport(ctx, dockerCli, repoInfo, endpoint, repoName)
+	if err != nil {
+		return nil, err
+	}
+	repo, err := client.NewRepository(ctx, repoNameRef, endpoint.URL.String(), tr)
+	if err != nil {
+		return nil, err
+	}
+	return repo, nil
+}
+
+// GetDistClientTransport builds a transport for use in communicating with a registry
+func GetDistClientTransport(ctx context.Context, dockerCli command.Cli, repoInfo *registry.RepositoryInfo, endpoint registry.APIEndpoint, repoName string) (http.RoundTripper, error) {
+	// get the http transport, this will be used in a client to upload manifest
+	base := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		Dial: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+			DualStack: true,
+		}).Dial,
+		TLSHandshakeTimeout: 10 * time.Second,
+		TLSClientConfig:     endpoint.TLSConfig,
+		DisableKeepAlives:   true,
+	}
+
+	authConfig := command.ResolveAuthConfig(ctx, dockerCli, repoInfo.Index)
+	modifiers := registry.DockerHeaders(dockerversion.DockerUserAgent(nil), http.Header{})
+	authTransport := transport.NewTransport(base, modifiers...)
+	challengeManager, confirmedV2, err := registry.PingV2Registry(endpoint.URL, authTransport)
+	if err != nil {
+		return nil, errors.Wrap(err, "error pinging v2 registry")
+	}
+	if !confirmedV2 {
+		return nil, fmt.Errorf("unsupported registry version")
+	}
+	if authConfig.RegistryToken != "" {
+		passThruTokenHandler := &existingTokenHandler{token: authConfig.RegistryToken}
+		modifiers = append(modifiers, auth.NewAuthorizer(challengeManager, passThruTokenHandler))
+	} else {
+		creds := registry.NewStaticCredentialStore(&authConfig)
+		tokenHandler := auth.NewTokenHandler(authTransport, creds, repoName, "*")
+		basicHandler := auth.NewBasicHandler(creds)
+		modifiers = append(modifiers, auth.NewAuthorizer(challengeManager, tokenHandler, basicHandler))
+	}
+	return transport.NewTransport(base, modifiers...), nil
+}
+
+func continueOnError(err error) bool {
+	switch v := err.(type) {
+	case errcode.Errors:
+		if len(v) == 0 {
+			return true
+		}
+		return continueOnError(v[0])
+	case errcode.Error:
+		e := err.(errcode.Error)
+		switch e.Code {
+		// @TODO: We should try remaning endpoints in these cases?
+		case errcode.ErrorCodeUnauthorized, v2.ErrorCodeManifestUnknown, v2.ErrorCodeNameUnknown:
+			return true
+		}
+		return false
+	case *client.UnexpectedHTTPResponseError:
+		return true
+	case ImageConfigPullError:
+		return false
+	}
+	// let's be nice and fallback if the error is a completely
+	// unexpected one.
+	// If new errors have to be handled in some way, please
+	// add them to the switch above.
+	return true
+}
+
+func makeImgManifestInspect(name string, img *Image, tag string, mfInfo manifestInfo, mediaType string, tagList []string) *ImgManifestInspect {
+	var digest digest.Digest
+	if err := mfInfo.digest.Validate(); err == nil {
+		digest = mfInfo.digest
+	}
+
+	if mediaType == manifestlist.MediaTypeManifestList {
+		return &ImgManifestInspect{
+			MediaType: mediaType,
+			Digest:    digest,
+		}
+	}
+
+	var digests []string
+	for _, blobDigest := range mfInfo.blobDigests {
+		digests = append(digests, blobDigest.String())
+	}
+	return &ImgManifestInspect{
+		RefName:         name,
+		Size:            mfInfo.length,
+		MediaType:       mediaType,
+		Tag:             tag,
+		Digest:          digest,
+		RepoTags:        tagList,
+		Comment:         img.Comment,
+		Created:         img.Created.Format(time.RFC3339Nano),
+		ContainerConfig: &img.ContainerConfig,
+		DockerVersion:   img.DockerVersion,
+		Author:          img.Author,
+		Config:          img.Config,
+		Architecture:    mfInfo.platform.Architecture,
+		OS:              mfInfo.platform.OS,
+		OSVersion:       mfInfo.platform.OSVersion,
+		OSFeatures:      mfInfo.platform.OSFeatures,
+		Variant:         mfInfo.platform.Variant,
+		Features:        mfInfo.platform.Features,
+		References:      digests,
+		LayerDigests:    mfInfo.layers,
+		CanonicalJSON:   mfInfo.jsonBytes,
+	}
+}

--- a/cli/manifest/fetcher/types.go
+++ b/cli/manifest/fetcher/types.go
@@ -114,25 +114,14 @@ type Image struct {
 	History    []History     `json:"history,omitempty"`
 	OSVersion  string        `json:"os.version,omitempty"`
 	OSFeatures []string      `json:"os.features,omitempty"`
-
-	// rawJSON caches the immutable JSON associated with this image.
-	rawJSON []byte
-
-	// computedID is the ID computed from the hash of the image config.
-	// Not to be confused with the legacy V1 ID in V1Image.
-	computedID digest.Digest // nolint: unused
 }
 
 // NewImageFromJSON creates an Image configuration from json.
 func NewImageFromJSON(src []byte) (*Image, error) {
 	img := &Image{}
-
 	if err := json.Unmarshal(src, img); err != nil {
 		return nil, err
 	}
-
-	img.rawJSON = src
-
 	return img, nil
 }
 

--- a/cli/manifest/fetcher/types.go
+++ b/cli/manifest/fetcher/types.go
@@ -1,0 +1,150 @@
+package fetcher
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	containerTypes "github.com/docker/docker/api/types/container"
+	"github.com/opencontainers/go-digest"
+)
+
+// RecoverableError signifies that other endpoints should be tried
+type RecoverableError struct {
+	original error
+}
+
+func (e RecoverableError) Error() string {
+	return fmt.Sprintf("non-fatal fetch error: %s", e.original.Error())
+}
+
+// ImageConfigPullError is an error pulling the image config blob
+// (only applies to schema2).
+type ImageConfigPullError struct {
+	Err error
+}
+
+// Error returns the error string for ImageConfigPullError.
+func (e ImageConfigPullError) Error() string {
+	return "error pulling image configuration: " + e.Err.Error()
+}
+
+// ImgManifestInspect contains info to output for a manifest object.
+type ImgManifestInspect struct {
+	RefName         string                 `json:"ref"`
+	Size            int64                  `json:"size"`
+	MediaType       string                 `json:"media_type"`
+	Tag             string                 `json:"tag"`
+	Digest          digest.Digest          `json:"digest"`
+	RepoTags        []string               `json:"repotags"`
+	Comment         string                 `json:"comment"`
+	Created         string                 `json:"created"`
+	ContainerConfig *containerTypes.Config `json:"container_config"`
+	DockerVersion   string                 `json:"docker_version"`
+	Author          string                 `json:"author"`
+	Config          *containerTypes.Config `json:"config"`
+	References      []string               `json:"references"`
+	LayerDigests    []string               `json:"layers_digests"`
+	Architecture    string                 `json:"architecture"`
+	OS              string                 `json:"os"`
+	OSVersion       string                 `json:"os.version,omitempty"`
+	OSFeatures      []string               `json:"os.features,omitempty"`
+	Variant         string                 `json:"variant,omitempty"`
+	Features        []string               `json:"features,omitempty"`
+	CanonicalJSON   []byte                 `json:"json"`
+}
+
+// The following mirror data structures from docker/docker/ to avoid importing all of distribtion/
+// Types have been substituted where possible to keep imports to a minimum, but maintain the Image structure
+// for use when unmarshaling docker/docker's image.Image JSON into a fetcher.Image.
+
+// RootFS describes images root filesystem
+type RootFS struct {
+	// @TODO: consider moving the following to a more universal location (outside the manifest/fetcher pkg)
+	Type    string          `json:"type"`
+	DiffIDs []digest.Digest `json:"diff_ids,omitempty"`
+}
+
+// History stores build commands that were used to create an image
+type History struct {
+	// Created is the timestamp at which the image was created
+	Created time.Time `json:"created"`
+	// Author is the name of the author that was specified when committing the image
+	Author string `json:"author,omitempty"`
+	// CreatedBy keeps the Dockerfile command used while building the image
+	CreatedBy string `json:"created_by,omitempty"`
+	// Comment is the commit message that was set when committing the image
+	Comment string `json:"comment,omitempty"`
+	// EmptyLayer is set to true if this history item did not generate a
+	// layer. Otherwise, the history item is associated with the next
+	// layer in the RootFS section.
+	EmptyLayer bool `json:"empty_layer,omitempty"`
+}
+
+// Image stores the image configuration
+// It contains docker's v1Image fields for simplicity
+type Image struct {
+	// ID is a unique 64 character identifier of the image
+	ID string `json:"id,omitempty"`
+	// Parent is the ID of the parent image
+	OldParent string `json:"oldparent,omitempty"`
+	// Comment is the commit message that was set when committing the image
+	Comment string `json:"comment,omitempty"`
+	// Created is the timestamp at which the image was created
+	Created time.Time `json:"created"`
+	// Container is the id of the container used to commit
+	Container string `json:"container,omitempty"`
+	// ContainerConfig is the configuration of the container that is committed into the image
+	ContainerConfig containerTypes.Config `json:"container_config,omitempty"`
+	// DockerVersion specifies the version of Docker that was used to build the image
+	DockerVersion string `json:"docker_version,omitempty"`
+	// Author is the name of the author that was specified when committing the image
+	Author string `json:"author,omitempty"`
+	// Config is the configuration of the container received from the client
+	Config *containerTypes.Config `json:"config,omitempty"`
+	// Architecture is the hardware that the image is built and runs on
+	Architecture string `json:"architecture,omitempty"`
+	// OS is the operating system used to build and run the image
+	OS string `json:"os,omitempty"`
+	// Size is the total size of the image including all layers it is composed of
+	Size       int64         `json:",omitempty"`
+	Parent     digest.Digest `json:"parent,omitempty"`
+	RootFS     *RootFS       `json:"rootfs,omitempty"`
+	History    []History     `json:"history,omitempty"`
+	OSVersion  string        `json:"os.version,omitempty"`
+	OSFeatures []string      `json:"os.features,omitempty"`
+
+	// rawJSON caches the immutable JSON associated with this image.
+	rawJSON []byte
+
+	// computedID is the ID computed from the hash of the image config.
+	// Not to be confused with the legacy V1 ID in V1Image.
+	computedID digest.Digest // nolint: unused
+}
+
+// NewImageFromJSON creates an Image configuration from json.
+func NewImageFromJSON(src []byte) (*Image, error) {
+	img := &Image{}
+
+	if err := json.Unmarshal(src, img); err != nil {
+		return nil, err
+	}
+
+	img.rawJSON = src
+
+	return img, nil
+}
+
+type existingTokenHandler struct {
+	token string
+}
+
+func (th *existingTokenHandler) AuthorizeRequest(req *http.Request, params map[string]string) error {
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", th.token))
+	return nil
+}
+
+func (th *existingTokenHandler) Scheme() string {
+	return "bearer"
+}

--- a/cli/manifest/store/store.go
+++ b/cli/manifest/store/store.go
@@ -1,0 +1,124 @@
+package store
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/cli/cli/manifest/fetcher"
+	"github.com/docker/distribution/reference"
+)
+
+// Store manages local storage of image distribution manifests
+type Store interface {
+	Remove(listRef reference.Reference) error
+	Get(listRef reference.Reference, manifest reference.Reference) (*fetcher.ImgManifestInspect, error)
+	GetList(listRef reference.Reference) ([]fetcher.ImgManifestInspect, error)
+	Save(listRef reference.Reference, manifest reference.Reference, image fetcher.ImgManifestInspect) error
+}
+
+// fsStore manages manifest files stored on the local filesystem
+type fsStore struct {
+	root string
+}
+
+// NewStore returns a new store for a local file path
+func NewStore(root string) Store {
+	return &fsStore{root: root}
+}
+
+// Remove a manifest list from local storage
+func (s *fsStore) Remove(listRef reference.Reference) error {
+	path := filepath.Join(s.root, makeFilesafeName(listRef.String()))
+	logrus.Debugf("manifest store: removing %s", path)
+	return os.RemoveAll(path)
+}
+
+// Get returns the local manifest
+// TODO: can transaction be something more strict than string? (same for other methods)
+func (s *fsStore) Get(listRef reference.Reference, manifest reference.Reference) (*fetcher.ImgManifestInspect, error) {
+	filename := manifestToFilename(s.root, listRef.String(), manifest.String())
+	return s.getFromFilename(filename)
+}
+
+func (s *fsStore) getFromFilename(filename string) (*fetcher.ImgManifestInspect, error) {
+	bytes, err := ioutil.ReadFile(filename)
+	switch {
+	case os.IsNotExist(err):
+		return nil, nil
+	case err != nil:
+		return nil, err
+	}
+	var manifestInfo fetcher.ImgManifestInspect
+	return &manifestInfo, json.Unmarshal(bytes, &manifestInfo)
+}
+
+// GetList returns all the local manifests for a transaction
+func (s *fsStore) GetList(listRef reference.Reference) ([]fetcher.ImgManifestInspect, error) {
+	filenames, err := s.listManifests(listRef.String())
+	if err != nil || filenames == nil {
+		return nil, err
+	}
+
+	manifests := []fetcher.ImgManifestInspect{}
+	for _, filename := range filenames {
+		filename = filepath.Join(s.root, makeFilesafeName(listRef.String()), filename)
+		manifest, err := s.getFromFilename(filename)
+		if err != nil {
+			return nil, err
+		}
+		if manifest == nil {
+			continue
+		}
+		manifests = append(manifests, *manifest)
+	}
+	return manifests, nil
+}
+
+// listManifests stored in a transaction
+func (s *fsStore) listManifests(transaction string) ([]string, error) {
+	transactionDir := filepath.Join(s.root, makeFilesafeName(transaction))
+	fileInfos, err := ioutil.ReadDir(transactionDir)
+	switch {
+	case os.IsNotExist(err):
+		return nil, nil
+	case err != nil:
+		return nil, err
+	}
+
+	filenames := []string{}
+	for _, info := range fileInfos {
+		filenames = append(filenames, info.Name())
+	}
+	return filenames, nil
+}
+
+// Save a manifest as part of a local manifest list
+func (s *fsStore) Save(listRef reference.Reference, manifest reference.Reference, image fetcher.ImgManifestInspect) error {
+	if err := s.createManifestListDirectory(listRef.String()); err != nil {
+		return err
+	}
+	filename := manifestToFilename(s.root, listRef.String(), manifest.String())
+	bytes, err := json.Marshal(image)
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(filename, bytes, 0644)
+}
+
+func (s *fsStore) createManifestListDirectory(transaction string) error {
+	path := filepath.Join(s.root, makeFilesafeName(transaction))
+	return os.MkdirAll(path, 0755)
+}
+
+func manifestToFilename(root, manifestList, manifest string) string {
+	return filepath.Join(root, makeFilesafeName(manifestList), makeFilesafeName(manifest))
+}
+
+func makeFilesafeName(ref string) string {
+	fileName := strings.Replace(ref, ":", "-", -1)
+	return strings.Replace(fileName, "/", "_", -1)
+}

--- a/cli/manifest/store/store_test.go
+++ b/cli/manifest/store/store_test.go
@@ -1,0 +1,100 @@
+package store
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/docker/cli/cli/manifest/fetcher"
+	"github.com/docker/distribution/reference"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeRef struct {
+	name string
+}
+
+func (f fakeRef) String() string {
+	return f.name
+}
+
+func ref(name string) fakeRef {
+	return fakeRef{name: name}
+}
+
+func newTestStore(t *testing.T) (Store, func()) {
+	tmpdir, err := ioutil.TempDir("", "manifest-store-test")
+	require.NoError(t, err)
+
+	return NewStore(tmpdir), func() { os.RemoveAll(tmpdir) }
+}
+
+func getFiles(t *testing.T, store Store) []os.FileInfo {
+	infos, err := ioutil.ReadDir(store.(*fsStore).root)
+	require.NoError(t, err)
+	return infos
+}
+
+func TestStoreRemove(t *testing.T) {
+	store, cleanup := newTestStore(t)
+	defer cleanup()
+
+	listRef := ref("list")
+	data := fetcher.ImgManifestInspect{RefName: "abcdef"}
+	require.NoError(t, store.Save(listRef, ref("manifest"), data))
+	require.Len(t, getFiles(t, store), 1)
+
+	assert.NoError(t, store.Remove(listRef))
+	assert.Len(t, getFiles(t, store), 0)
+}
+
+func TestStoreSaveAndGet(t *testing.T) {
+	store, cleanup := newTestStore(t)
+	defer cleanup()
+
+	listRef := ref("list")
+	data := fetcher.ImgManifestInspect{RefName: "abcdef"}
+	require.NoError(t, store.Save(listRef, ref("exists"), data))
+
+	var testcases = []struct {
+		listRef     reference.Reference
+		manifestRef reference.Reference
+		expected    *fetcher.ImgManifestInspect
+	}{
+		{
+			listRef:     listRef,
+			manifestRef: ref("exists"),
+			expected:    &data,
+		},
+		{
+			listRef:     listRef,
+			manifestRef: ref("does-not-exist"),
+		},
+		{
+			listRef:     ref("list-does-not-exist"),
+			manifestRef: ref("does-not-exist"),
+		},
+	}
+
+	for _, testcase := range testcases {
+		actual, err := store.Get(testcase.listRef, testcase.manifestRef)
+		assert.NoError(t, err)
+		assert.Equal(t, testcase.expected, actual)
+	}
+}
+
+func TestStoreGetList(t *testing.T) {
+	store, cleanup := newTestStore(t)
+	defer cleanup()
+
+	listRef := ref("list")
+	first := fetcher.ImgManifestInspect{RefName: "first"}
+	require.NoError(t, store.Save(listRef, ref("first"), first))
+	second := fetcher.ImgManifestInspect{RefName: "second"}
+	require.NoError(t, store.Save(listRef, ref("exists"), second))
+
+	list, err := store.GetList(listRef)
+	assert.NoError(t, err)
+	assert.Len(t, list, 2)
+}

--- a/vendor/github.com/docker/distribution/manifest/doc.go
+++ b/vendor/github.com/docker/distribution/manifest/doc.go
@@ -1,0 +1,1 @@
+package manifest

--- a/vendor/github.com/docker/distribution/manifest/manifestlist/manifestlist.go
+++ b/vendor/github.com/docker/distribution/manifest/manifestlist/manifestlist.go
@@ -1,0 +1,155 @@
+package manifestlist
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/manifest"
+	"github.com/opencontainers/go-digest"
+)
+
+// MediaTypeManifestList specifies the mediaType for manifest lists.
+const MediaTypeManifestList = "application/vnd.docker.distribution.manifest.list.v2+json"
+
+// SchemaVersion provides a pre-initialized version structure for this
+// packages version of the manifest.
+var SchemaVersion = manifest.Versioned{
+	SchemaVersion: 2,
+	MediaType:     MediaTypeManifestList,
+}
+
+func init() {
+	manifestListFunc := func(b []byte) (distribution.Manifest, distribution.Descriptor, error) {
+		m := new(DeserializedManifestList)
+		err := m.UnmarshalJSON(b)
+		if err != nil {
+			return nil, distribution.Descriptor{}, err
+		}
+
+		dgst := digest.FromBytes(b)
+		return m, distribution.Descriptor{Digest: dgst, Size: int64(len(b)), MediaType: MediaTypeManifestList}, err
+	}
+	err := distribution.RegisterManifestSchema(MediaTypeManifestList, manifestListFunc)
+	if err != nil {
+		panic(fmt.Sprintf("Unable to register manifest: %s", err))
+	}
+}
+
+// PlatformSpec specifies a platform where a particular image manifest is
+// applicable.
+type PlatformSpec struct {
+	// Architecture field specifies the CPU architecture, for example
+	// `amd64` or `ppc64`.
+	Architecture string `json:"architecture"`
+
+	// OS specifies the operating system, for example `linux` or `windows`.
+	OS string `json:"os"`
+
+	// OSVersion is an optional field specifying the operating system
+	// version, for example `10.0.10586`.
+	OSVersion string `json:"os.version,omitempty"`
+
+	// OSFeatures is an optional field specifying an array of strings,
+	// each listing a required OS feature (for example on Windows `win32k`).
+	OSFeatures []string `json:"os.features,omitempty"`
+
+	// Variant is an optional field specifying a variant of the CPU, for
+	// example `ppc64le` to specify a little-endian version of a PowerPC CPU.
+	Variant string `json:"variant,omitempty"`
+
+	// Features is an optional field specifying an array of strings, each
+	// listing a required CPU feature (for example `sse4` or `aes`).
+	Features []string `json:"features,omitempty"`
+}
+
+// A ManifestDescriptor references a platform-specific manifest.
+type ManifestDescriptor struct {
+	distribution.Descriptor
+
+	// Platform specifies which platform the manifest pointed to by the
+	// descriptor runs on.
+	Platform PlatformSpec `json:"platform"`
+}
+
+// ManifestList references manifests for various platforms.
+type ManifestList struct {
+	manifest.Versioned
+
+	// Config references the image configuration as a blob.
+	Manifests []ManifestDescriptor `json:"manifests"`
+}
+
+// References returnes the distribution descriptors for the referenced image
+// manifests.
+func (m ManifestList) References() []distribution.Descriptor {
+	dependencies := make([]distribution.Descriptor, len(m.Manifests))
+	for i := range m.Manifests {
+		dependencies[i] = m.Manifests[i].Descriptor
+	}
+
+	return dependencies
+}
+
+// DeserializedManifestList wraps ManifestList with a copy of the original
+// JSON.
+type DeserializedManifestList struct {
+	ManifestList
+
+	// canonical is the canonical byte representation of the Manifest.
+	canonical []byte
+}
+
+// FromDescriptors takes a slice of descriptors, and returns a
+// DeserializedManifestList which contains the resulting manifest list
+// and its JSON representation.
+func FromDescriptors(descriptors []ManifestDescriptor) (*DeserializedManifestList, error) {
+	m := ManifestList{
+		Versioned: SchemaVersion,
+	}
+
+	m.Manifests = make([]ManifestDescriptor, len(descriptors), len(descriptors))
+	copy(m.Manifests, descriptors)
+
+	deserialized := DeserializedManifestList{
+		ManifestList: m,
+	}
+
+	var err error
+	deserialized.canonical, err = json.MarshalIndent(&m, "", "   ")
+	return &deserialized, err
+}
+
+// UnmarshalJSON populates a new ManifestList struct from JSON data.
+func (m *DeserializedManifestList) UnmarshalJSON(b []byte) error {
+	m.canonical = make([]byte, len(b), len(b))
+	// store manifest list in canonical
+	copy(m.canonical, b)
+
+	// Unmarshal canonical JSON into ManifestList object
+	var manifestList ManifestList
+	if err := json.Unmarshal(m.canonical, &manifestList); err != nil {
+		return err
+	}
+
+	m.ManifestList = manifestList
+
+	return nil
+}
+
+// MarshalJSON returns the contents of canonical. If canonical is empty,
+// marshals the inner contents.
+func (m *DeserializedManifestList) MarshalJSON() ([]byte, error) {
+	if len(m.canonical) > 0 {
+		return m.canonical, nil
+	}
+
+	return nil, errors.New("JSON representation not initialized in DeserializedManifestList")
+}
+
+// Payload returns the raw content of the manifest list. The contents can be
+// used to calculate the content identifier.
+func (m DeserializedManifestList) Payload() (string, []byte, error) {
+	return m.MediaType, m.canonical, nil
+}

--- a/vendor/github.com/docker/distribution/manifest/schema2/builder.go
+++ b/vendor/github.com/docker/distribution/manifest/schema2/builder.go
@@ -1,0 +1,84 @@
+package schema2
+
+import (
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/context"
+	"github.com/opencontainers/go-digest"
+)
+
+// builder is a type for constructing manifests.
+type builder struct {
+	// bs is a BlobService used to publish the configuration blob.
+	bs distribution.BlobService
+
+	// configMediaType is media type used to describe configuration
+	configMediaType string
+
+	// configJSON references
+	configJSON []byte
+
+	// dependencies is a list of descriptors that gets built by successive
+	// calls to AppendReference. In case of image configuration these are layers.
+	dependencies []distribution.Descriptor
+}
+
+// NewManifestBuilder is used to build new manifests for the current schema
+// version. It takes a BlobService so it can publish the configuration blob
+// as part of the Build process.
+func NewManifestBuilder(bs distribution.BlobService, configMediaType string, configJSON []byte) distribution.ManifestBuilder {
+	mb := &builder{
+		bs:              bs,
+		configMediaType: configMediaType,
+		configJSON:      make([]byte, len(configJSON)),
+	}
+	copy(mb.configJSON, configJSON)
+
+	return mb
+}
+
+// Build produces a final manifest from the given references.
+func (mb *builder) Build(ctx context.Context) (distribution.Manifest, error) {
+	m := Manifest{
+		Versioned: SchemaVersion,
+		Layers:    make([]distribution.Descriptor, len(mb.dependencies)),
+	}
+	copy(m.Layers, mb.dependencies)
+
+	configDigest := digest.FromBytes(mb.configJSON)
+
+	var err error
+	m.Config, err = mb.bs.Stat(ctx, configDigest)
+	switch err {
+	case nil:
+		// Override MediaType, since Put always replaces the specified media
+		// type with application/octet-stream in the descriptor it returns.
+		m.Config.MediaType = mb.configMediaType
+		return FromStruct(m)
+	case distribution.ErrBlobUnknown:
+		// nop
+	default:
+		return nil, err
+	}
+
+	// Add config to the blob store
+	m.Config, err = mb.bs.Put(ctx, mb.configMediaType, mb.configJSON)
+	// Override MediaType, since Put always replaces the specified media
+	// type with application/octet-stream in the descriptor it returns.
+	m.Config.MediaType = mb.configMediaType
+	if err != nil {
+		return nil, err
+	}
+
+	return FromStruct(m)
+}
+
+// AppendReference adds a reference to the current ManifestBuilder.
+func (mb *builder) AppendReference(d distribution.Describable) error {
+	mb.dependencies = append(mb.dependencies, d.Descriptor())
+	return nil
+}
+
+// References returns the current references added to this builder.
+func (mb *builder) References() []distribution.Descriptor {
+	return mb.dependencies
+}

--- a/vendor/github.com/docker/distribution/manifest/schema2/manifest.go
+++ b/vendor/github.com/docker/distribution/manifest/schema2/manifest.go
@@ -1,0 +1,138 @@
+package schema2
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/manifest"
+	"github.com/opencontainers/go-digest"
+)
+
+const (
+	// MediaTypeManifest specifies the mediaType for the current version.
+	MediaTypeManifest = "application/vnd.docker.distribution.manifest.v2+json"
+
+	// MediaTypeImageConfig specifies the mediaType for the image configuration.
+	MediaTypeImageConfig = "application/vnd.docker.container.image.v1+json"
+
+	// MediaTypePluginConfig specifies the mediaType for plugin configuration.
+	MediaTypePluginConfig = "application/vnd.docker.plugin.v1+json"
+
+	// MediaTypeLayer is the mediaType used for layers referenced by the
+	// manifest.
+	MediaTypeLayer = "application/vnd.docker.image.rootfs.diff.tar.gzip"
+
+	// MediaTypeForeignLayer is the mediaType used for layers that must be
+	// downloaded from foreign URLs.
+	MediaTypeForeignLayer = "application/vnd.docker.image.rootfs.foreign.diff.tar.gzip"
+
+	// MediaTypeUncompressedLayer is the mediaType used for layers which
+	// are not compressed.
+	MediaTypeUncompressedLayer = "application/vnd.docker.image.rootfs.diff.tar"
+)
+
+var (
+	// SchemaVersion provides a pre-initialized version structure for this
+	// packages version of the manifest.
+	SchemaVersion = manifest.Versioned{
+		SchemaVersion: 2,
+		MediaType:     MediaTypeManifest,
+	}
+)
+
+func init() {
+	schema2Func := func(b []byte) (distribution.Manifest, distribution.Descriptor, error) {
+		m := new(DeserializedManifest)
+		err := m.UnmarshalJSON(b)
+		if err != nil {
+			return nil, distribution.Descriptor{}, err
+		}
+
+		dgst := digest.FromBytes(b)
+		return m, distribution.Descriptor{Digest: dgst, Size: int64(len(b)), MediaType: MediaTypeManifest}, err
+	}
+	err := distribution.RegisterManifestSchema(MediaTypeManifest, schema2Func)
+	if err != nil {
+		panic(fmt.Sprintf("Unable to register manifest: %s", err))
+	}
+}
+
+// Manifest defines a schema2 manifest.
+type Manifest struct {
+	manifest.Versioned
+
+	// Config references the image configuration as a blob.
+	Config distribution.Descriptor `json:"config"`
+
+	// Layers lists descriptors for the layers referenced by the
+	// configuration.
+	Layers []distribution.Descriptor `json:"layers"`
+}
+
+// References returnes the descriptors of this manifests references.
+func (m Manifest) References() []distribution.Descriptor {
+	references := make([]distribution.Descriptor, 0, 1+len(m.Layers))
+	references = append(references, m.Config)
+	references = append(references, m.Layers...)
+	return references
+}
+
+// Target returns the target of this signed manifest.
+func (m Manifest) Target() distribution.Descriptor {
+	return m.Config
+}
+
+// DeserializedManifest wraps Manifest with a copy of the original JSON.
+// It satisfies the distribution.Manifest interface.
+type DeserializedManifest struct {
+	Manifest
+
+	// canonical is the canonical byte representation of the Manifest.
+	canonical []byte
+}
+
+// FromStruct takes a Manifest structure, marshals it to JSON, and returns a
+// DeserializedManifest which contains the manifest and its JSON representation.
+func FromStruct(m Manifest) (*DeserializedManifest, error) {
+	var deserialized DeserializedManifest
+	deserialized.Manifest = m
+
+	var err error
+	deserialized.canonical, err = json.MarshalIndent(&m, "", "   ")
+	return &deserialized, err
+}
+
+// UnmarshalJSON populates a new Manifest struct from JSON data.
+func (m *DeserializedManifest) UnmarshalJSON(b []byte) error {
+	m.canonical = make([]byte, len(b), len(b))
+	// store manifest in canonical
+	copy(m.canonical, b)
+
+	// Unmarshal canonical JSON into Manifest object
+	var manifest Manifest
+	if err := json.Unmarshal(m.canonical, &manifest); err != nil {
+		return err
+	}
+
+	m.Manifest = manifest
+
+	return nil
+}
+
+// MarshalJSON returns the contents of canonical. If canonical is empty,
+// marshals the inner contents.
+func (m *DeserializedManifest) MarshalJSON() ([]byte, error) {
+	if len(m.canonical) > 0 {
+		return m.canonical, nil
+	}
+
+	return nil, errors.New("JSON representation not initialized in DeserializedManifest")
+}
+
+// Payload returns the raw content of the manifest. The contents can be used to
+// calculate the content identifier.
+func (m DeserializedManifest) Payload() (string, []byte, error) {
+	return m.MediaType, m.canonical, nil
+}

--- a/vendor/github.com/docker/distribution/manifest/versioned.go
+++ b/vendor/github.com/docker/distribution/manifest/versioned.go
@@ -1,0 +1,12 @@
+package manifest
+
+// Versioned provides a struct with the manifest schemaVersion and mediaType.
+// Incoming content with unknown schema version can be decoded against this
+// struct to check the version.
+type Versioned struct {
+	// SchemaVersion is the image manifest schema that this image follows
+	SchemaVersion int `json:"schemaVersion"`
+
+	// MediaType is the media type of this schema.
+	MediaType string `json:"mediaType,omitempty"`
+}

--- a/vendor/github.com/docker/docker/dockerversion/useragent.go
+++ b/vendor/github.com/docker/docker/dockerversion/useragent.go
@@ -1,0 +1,76 @@
+package dockerversion
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/docker/docker/pkg/parsers/kernel"
+	"github.com/docker/docker/pkg/useragent"
+	"golang.org/x/net/context"
+)
+
+// UAStringKey is used as key type for user-agent string in net/context struct
+const UAStringKey = "upstream-user-agent"
+
+// DockerUserAgent is the User-Agent the Docker client uses to identify itself.
+// In accordance with RFC 7231 (5.5.3) is of the form:
+//    [docker client's UA] UpstreamClient([upstream client's UA])
+func DockerUserAgent(ctx context.Context) string {
+	httpVersion := make([]useragent.VersionInfo, 0, 6)
+	httpVersion = append(httpVersion, useragent.VersionInfo{Name: "docker", Version: Version})
+	httpVersion = append(httpVersion, useragent.VersionInfo{Name: "go", Version: runtime.Version()})
+	httpVersion = append(httpVersion, useragent.VersionInfo{Name: "git-commit", Version: GitCommit})
+	if kernelVersion, err := kernel.GetKernelVersion(); err == nil {
+		httpVersion = append(httpVersion, useragent.VersionInfo{Name: "kernel", Version: kernelVersion.String()})
+	}
+	httpVersion = append(httpVersion, useragent.VersionInfo{Name: "os", Version: runtime.GOOS})
+	httpVersion = append(httpVersion, useragent.VersionInfo{Name: "arch", Version: runtime.GOARCH})
+
+	dockerUA := useragent.AppendVersions("", httpVersion...)
+	upstreamUA := getUserAgentFromContext(ctx)
+	if len(upstreamUA) > 0 {
+		ret := insertUpstreamUserAgent(upstreamUA, dockerUA)
+		return ret
+	}
+	return dockerUA
+}
+
+// getUserAgentFromContext returns the previously saved user-agent context stored in ctx, if one exists
+func getUserAgentFromContext(ctx context.Context) string {
+	var upstreamUA string
+	if ctx != nil {
+		var ki interface{} = ctx.Value(UAStringKey)
+		if ki != nil {
+			upstreamUA = ctx.Value(UAStringKey).(string)
+		}
+	}
+	return upstreamUA
+}
+
+// escapeStr returns s with every rune in charsToEscape escaped by a backslash
+func escapeStr(s string, charsToEscape string) string {
+	var ret string
+	for _, currRune := range s {
+		appended := false
+		for _, escapeableRune := range charsToEscape {
+			if currRune == escapeableRune {
+				ret += `\` + string(currRune)
+				appended = true
+				break
+			}
+		}
+		if !appended {
+			ret += string(currRune)
+		}
+	}
+	return ret
+}
+
+// insertUpstreamUserAgent adds the upstream client useragent to create a user-agent
+// string of the form:
+//   $dockerUA UpstreamClient($upstreamUA)
+func insertUpstreamUserAgent(upstreamUA string, dockerUA string) string {
+	charsToEscape := `();\`
+	upstreamUAEscaped := escapeStr(upstreamUA, charsToEscape)
+	return fmt.Sprintf("%s UpstreamClient(%s)", dockerUA, upstreamUAEscaped)
+}

--- a/vendor/github.com/docker/docker/dockerversion/version_lib.go
+++ b/vendor/github.com/docker/docker/dockerversion/version_lib.go
@@ -1,0 +1,16 @@
+// +build !autogen
+
+// Package dockerversion is auto-generated at build-time
+package dockerversion
+
+// Default build-time variable for library-import.
+// This file is overridden on build with build-time informations.
+const (
+	GitCommit          string = "library-import"
+	Version            string = "library-import"
+	BuildTime          string = "library-import"
+	IAmStatic          string = "library-import"
+	ContainerdCommitID string = "library-import"
+	RuncCommitID       string = "library-import"
+	InitCommitID       string = "library-import"
+)

--- a/vendor/github.com/docker/docker/pkg/parsers/kernel/kernel.go
+++ b/vendor/github.com/docker/docker/pkg/parsers/kernel/kernel.go
@@ -1,0 +1,74 @@
+// +build !windows
+
+// Package kernel provides helper function to get, parse and compare kernel
+// versions for different platforms.
+package kernel
+
+import (
+	"errors"
+	"fmt"
+)
+
+// VersionInfo holds information about the kernel.
+type VersionInfo struct {
+	Kernel int    // Version of the kernel (e.g. 4.1.2-generic -> 4)
+	Major  int    // Major part of the kernel version (e.g. 4.1.2-generic -> 1)
+	Minor  int    // Minor part of the kernel version (e.g. 4.1.2-generic -> 2)
+	Flavor string // Flavor of the kernel version (e.g. 4.1.2-generic -> generic)
+}
+
+func (k *VersionInfo) String() string {
+	return fmt.Sprintf("%d.%d.%d%s", k.Kernel, k.Major, k.Minor, k.Flavor)
+}
+
+// CompareKernelVersion compares two kernel.VersionInfo structs.
+// Returns -1 if a < b, 0 if a == b, 1 it a > b
+func CompareKernelVersion(a, b VersionInfo) int {
+	if a.Kernel < b.Kernel {
+		return -1
+	} else if a.Kernel > b.Kernel {
+		return 1
+	}
+
+	if a.Major < b.Major {
+		return -1
+	} else if a.Major > b.Major {
+		return 1
+	}
+
+	if a.Minor < b.Minor {
+		return -1
+	} else if a.Minor > b.Minor {
+		return 1
+	}
+
+	return 0
+}
+
+// ParseRelease parses a string and creates a VersionInfo based on it.
+func ParseRelease(release string) (*VersionInfo, error) {
+	var (
+		kernel, major, minor, parsed int
+		flavor, partial              string
+	)
+
+	// Ignore error from Sscanf to allow an empty flavor.  Instead, just
+	// make sure we got all the version numbers.
+	parsed, _ = fmt.Sscanf(release, "%d.%d%s", &kernel, &major, &partial)
+	if parsed < 2 {
+		return nil, errors.New("Can't parse kernel version " + release)
+	}
+
+	// sometimes we have 3.12.25-gentoo, but sometimes we just have 3.12-1-amd64
+	parsed, _ = fmt.Sscanf(partial, ".%d%s", &minor, &flavor)
+	if parsed < 1 {
+		flavor = partial
+	}
+
+	return &VersionInfo{
+		Kernel: kernel,
+		Major:  major,
+		Minor:  minor,
+		Flavor: flavor,
+	}, nil
+}

--- a/vendor/github.com/docker/docker/pkg/parsers/kernel/kernel_darwin.go
+++ b/vendor/github.com/docker/docker/pkg/parsers/kernel/kernel_darwin.go
@@ -1,0 +1,56 @@
+// +build darwin
+
+// Package kernel provides helper function to get, parse and compare kernel
+// versions for different platforms.
+package kernel
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/mattn/go-shellwords"
+)
+
+// GetKernelVersion gets the current kernel version.
+func GetKernelVersion() (*VersionInfo, error) {
+	release, err := getRelease()
+	if err != nil {
+		return nil, err
+	}
+
+	return ParseRelease(release)
+}
+
+// getRelease uses `system_profiler SPSoftwareDataType` to get OSX kernel version
+func getRelease() (string, error) {
+	cmd := exec.Command("system_profiler", "SPSoftwareDataType")
+	osName, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+
+	var release string
+	data := strings.Split(string(osName), "\n")
+	for _, line := range data {
+		if strings.Contains(line, "Kernel Version") {
+			// It has the format like '      Kernel Version: Darwin 14.5.0'
+			content := strings.SplitN(line, ":", 2)
+			if len(content) != 2 {
+				return "", fmt.Errorf("Kernel Version is invalid")
+			}
+
+			prettyNames, err := shellwords.Parse(content[1])
+			if err != nil {
+				return "", fmt.Errorf("Kernel Version is invalid: %s", err.Error())
+			}
+
+			if len(prettyNames) != 2 {
+				return "", fmt.Errorf("Kernel Version needs to be 'Darwin x.x.x' ")
+			}
+			release = prettyNames[1]
+		}
+	}
+
+	return release, nil
+}

--- a/vendor/github.com/docker/docker/pkg/parsers/kernel/kernel_unix.go
+++ b/vendor/github.com/docker/docker/pkg/parsers/kernel/kernel_unix.go
@@ -1,0 +1,45 @@
+// +build linux freebsd solaris openbsd
+
+// Package kernel provides helper function to get, parse and compare kernel
+// versions for different platforms.
+package kernel
+
+import (
+	"bytes"
+
+	"github.com/Sirupsen/logrus"
+)
+
+// GetKernelVersion gets the current kernel version.
+func GetKernelVersion() (*VersionInfo, error) {
+	uts, err := uname()
+	if err != nil {
+		return nil, err
+	}
+
+	release := make([]byte, len(uts.Release))
+
+	i := 0
+	for _, c := range uts.Release {
+		release[i] = byte(c)
+		i++
+	}
+
+	// Remove the \x00 from the release for Atoi to parse correctly
+	release = release[:bytes.IndexByte(release, 0)]
+
+	return ParseRelease(string(release))
+}
+
+// CheckKernelVersion checks if current kernel is newer than (or equal to)
+// the given version.
+func CheckKernelVersion(k, major, minor int) bool {
+	if v, err := GetKernelVersion(); err != nil {
+		logrus.Warnf("error getting kernel version: %s", err)
+	} else {
+		if CompareKernelVersion(*v, VersionInfo{Kernel: k, Major: major, Minor: minor}) < 0 {
+			return false
+		}
+	}
+	return true
+}

--- a/vendor/github.com/docker/docker/pkg/parsers/kernel/kernel_windows.go
+++ b/vendor/github.com/docker/docker/pkg/parsers/kernel/kernel_windows.go
@@ -1,0 +1,69 @@
+// +build windows
+
+package kernel
+
+import (
+	"fmt"
+	"syscall"
+	"unsafe"
+)
+
+// VersionInfo holds information about the kernel.
+type VersionInfo struct {
+	kvi   string // Version of the kernel (e.g. 6.1.7601.17592 -> 6)
+	major int    // Major part of the kernel version (e.g. 6.1.7601.17592 -> 1)
+	minor int    // Minor part of the kernel version (e.g. 6.1.7601.17592 -> 7601)
+	build int    // Build number of the kernel version (e.g. 6.1.7601.17592 -> 17592)
+}
+
+func (k *VersionInfo) String() string {
+	return fmt.Sprintf("%d.%d %d (%s)", k.major, k.minor, k.build, k.kvi)
+}
+
+// GetKernelVersion gets the current kernel version.
+func GetKernelVersion() (*VersionInfo, error) {
+
+	var (
+		h         syscall.Handle
+		dwVersion uint32
+		err       error
+	)
+
+	KVI := &VersionInfo{"Unknown", 0, 0, 0}
+
+	if err = syscall.RegOpenKeyEx(syscall.HKEY_LOCAL_MACHINE,
+		syscall.StringToUTF16Ptr(`SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\`),
+		0,
+		syscall.KEY_READ,
+		&h); err != nil {
+		return KVI, err
+	}
+	defer syscall.RegCloseKey(h)
+
+	var buf [1 << 10]uint16
+	var typ uint32
+	n := uint32(len(buf) * 2) // api expects array of bytes, not uint16
+
+	if err = syscall.RegQueryValueEx(h,
+		syscall.StringToUTF16Ptr("BuildLabEx"),
+		nil,
+		&typ,
+		(*byte)(unsafe.Pointer(&buf[0])),
+		&n); err != nil {
+		return KVI, err
+	}
+
+	KVI.kvi = syscall.UTF16ToString(buf[:])
+
+	// Important - docker.exe MUST be manifested for this API to return
+	// the correct information.
+	if dwVersion, err = syscall.GetVersion(); err != nil {
+		return KVI, err
+	}
+
+	KVI.major = int(dwVersion & 0xFF)
+	KVI.minor = int((dwVersion & 0XFF00) >> 8)
+	KVI.build = int((dwVersion & 0xFFFF0000) >> 16)
+
+	return KVI, nil
+}

--- a/vendor/github.com/docker/docker/pkg/parsers/kernel/uname_linux.go
+++ b/vendor/github.com/docker/docker/pkg/parsers/kernel/uname_linux.go
@@ -1,0 +1,19 @@
+package kernel
+
+import (
+	"syscall"
+)
+
+// Utsname represents the system name structure.
+// It is passthrough for syscall.Utsname in order to make it portable with
+// other platforms where it is not available.
+type Utsname syscall.Utsname
+
+func uname() (*syscall.Utsname, error) {
+	uts := &syscall.Utsname{}
+
+	if err := syscall.Uname(uts); err != nil {
+		return nil, err
+	}
+	return uts, nil
+}

--- a/vendor/github.com/docker/docker/pkg/parsers/kernel/uname_solaris.go
+++ b/vendor/github.com/docker/docker/pkg/parsers/kernel/uname_solaris.go
@@ -1,0 +1,14 @@
+package kernel
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+func uname() (*unix.Utsname, error) {
+	uts := &unix.Utsname{}
+
+	if err := unix.Uname(uts); err != nil {
+		return nil, err
+	}
+	return uts, nil
+}

--- a/vendor/github.com/docker/docker/pkg/parsers/kernel/uname_unsupported.go
+++ b/vendor/github.com/docker/docker/pkg/parsers/kernel/uname_unsupported.go
@@ -1,0 +1,18 @@
+// +build !linux,!solaris
+
+package kernel
+
+import (
+	"errors"
+)
+
+// Utsname represents the system name structure.
+// It is defined here to make it portable as it is available on linux but not
+// on windows.
+type Utsname struct {
+	Release [65]byte
+}
+
+func uname() (*Utsname, error) {
+	return nil, errors.New("Kernel version detection is available only on linux")
+}

--- a/vendor/github.com/docker/docker/pkg/useragent/README.md
+++ b/vendor/github.com/docker/docker/pkg/useragent/README.md
@@ -1,0 +1,1 @@
+This package provides helper functions to pack version information into a single User-Agent header.

--- a/vendor/github.com/docker/docker/pkg/useragent/useragent.go
+++ b/vendor/github.com/docker/docker/pkg/useragent/useragent.go
@@ -1,0 +1,55 @@
+// Package useragent provides helper functions to pack
+// version information into a single User-Agent header.
+package useragent
+
+import (
+	"strings"
+)
+
+// VersionInfo is used to model UserAgent versions.
+type VersionInfo struct {
+	Name    string
+	Version string
+}
+
+func (vi *VersionInfo) isValid() bool {
+	const stopChars = " \t\r\n/"
+	name := vi.Name
+	vers := vi.Version
+	if len(name) == 0 || strings.ContainsAny(name, stopChars) {
+		return false
+	}
+	if len(vers) == 0 || strings.ContainsAny(vers, stopChars) {
+		return false
+	}
+	return true
+}
+
+// AppendVersions converts versions to a string and appends the string to the string base.
+//
+// Each VersionInfo will be converted to a string in the format of
+// "product/version", where the "product" is get from the name field, while
+// version is get from the version field. Several pieces of version information
+// will be concatenated and separated by space.
+//
+// Example:
+// AppendVersions("base", VersionInfo{"foo", "1.0"}, VersionInfo{"bar", "2.0"})
+// results in "base foo/1.0 bar/2.0".
+func AppendVersions(base string, versions ...VersionInfo) string {
+	if len(versions) == 0 {
+		return base
+	}
+
+	verstrs := make([]string, 0, 1+len(versions))
+	if len(base) > 0 {
+		verstrs = append(verstrs, base)
+	}
+
+	for _, v := range versions {
+		if !v.isValid() {
+			continue
+		}
+		verstrs = append(verstrs, v.Name+"/"+v.Version)
+	}
+	return strings.Join(verstrs, " ")
+}


### PR DESCRIPTION
Branched from #3

Extract a manifest store for managing operations on the local manifest files.

Also uncoupled the save operation that was embedded into fetch.

Removed the duplicate calls for normalizing a reference by extracting them to a new function.